### PR TITLE
fix: authorize live dials before config checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-13
+
+- Authorized live dial requests before returning detailed Twilio credential,
+  sender, or callback-origin configuration errors, while preserving
+  unauthenticated dry runs.
+
 ## 2026-06-12
 
 - Required the exact `application/x-www-form-urlencoded` media type on the

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Tests cover safe `PORT` parsing before the built-in HTTP server starts.
 - Tests cover dial-target redaction in response messages.
 - Tests require a constant-time authorization-token match before live dialing.
+  Live requests check that token before returning detailed Twilio credential,
+  sender, or callback-origin configuration errors; dry runs remain
+  unauthenticated and credential-free.
 - Tests require provider failures to return a generic `502` without leaking
   exception details.
 - Tests require oversized dial forms to return `413` before parsing or dialing.
@@ -148,6 +151,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   dependency cleanup coverage.
 - See `docs/plans/2026-06-10-dependencies-and-ci.md` for stable dependency and
   hosted Java matrix verification.
+- See `docs/plans/2026-06-13-live-dial-authorization-order.md` for the
+  authentication-first live request boundary.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,9 @@ Helpful reports include:
 
 - This repository appears to be a public sample, documentation, or utility project. The active security scope is the code and documentation on the default branch.
 - Review found authentication, token, or session-related code paths; changes in those areas should receive security-focused review before merge.
+- Live dial requests must authorize the per-request dial token before returning
+  detailed Twilio provider configuration errors. Dry-run requests intentionally
+  remain available without that token and do not create outbound calls.
 - Review found external API integrations or credential-adjacent configuration; changes in those areas should receive security-focused review before merge.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.
 - Review found mobile permission or privacy-sensitive data handling; changes in those areas should receive security-focused review before merge.

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,7 @@ Priority:
 - Require callback base URLs to be parseable HTTPS origins
 - Keep outbound calls in dry-run mode unless explicitly enabled
 - Require per-request authorization before any live dial attempt
+- Authorize live requests before disclosing provider configuration details
 - Keep Twilio provider failure diagnostics out of HTTP responses
 - Keep every HTTP response non-cacheable, non-frameable, and constrained by a
   restrictive browser security policy

--- a/docs/plans/2026-06-13-live-dial-authorization-order.md
+++ b/docs/plans/2026-06-13-live-dial-authorization-order.md
@@ -1,0 +1,88 @@
+---
+title: "fix: Authorize live dial requests before configuration disclosure"
+type: fix
+date: 2026-06-13
+---
+
+# Authorize Live Dial Requests Before Configuration Disclosure
+
+## Status: Completed
+
+## Context
+
+The live dial path currently validates Twilio credentials, the configured
+sender, and the callback origin before it checks the separately configured dial
+authorization token. An unauthenticated caller can therefore distinguish
+missing or malformed provider configuration from a valid setup.
+
+## Requirements
+
+- R1. In live mode, require the configured dial token and authorize the
+  provided token before returning Twilio credential, sender, or callback-origin
+  validation details.
+- R2. Preserve the existing `503` response when the server-side dial token is
+  missing and the existing `403` response for an incorrect provided token.
+- R3. Preserve credential-free, unauthenticated dry-run behavior.
+- R4. Continue validating all provider configuration before constructing or
+  invoking a Twilio client for an authorized live request.
+- R5. Add direct and loopback coverage proving unauthorized live requests do
+  not disclose provider configuration or invoke the call sender.
+- R6. Add a static ordering contract and hostile mutations for authorization
+  removal or movement after provider validation.
+
+## Scope Boundaries
+
+This change only reorders validation within the existing live dial path. It
+does not change token comparison, add sessions, rate limiting, credential-shape
+validation, or make a live Twilio request.
+
+## Implementation Units
+
+### U1. Reorder the Live Authorization Boundary
+
+- **Goal:** Authenticate a live dial request before detailed provider setup is
+  evaluated.
+- **Files:** `src/main/java/org/example/Main.java`
+- **Approach:** Determine live mode after target validation, enforce the
+  configured and provided dial tokens, then evaluate Twilio call configuration.
+- **Verification:** Dry runs remain unauthenticated; authorized live requests
+  still validate provider setup before the call sender runs.
+
+### U2. Add Disclosure and Ordering Coverage
+
+- **Goal:** Prevent validation order from regressing.
+- **Files:** `src/test/java/org/example/MainTest.java`,
+  `scripts/check-baseline.sh`
+- **Approach:** Add direct and loopback cases with deliberately missing
+  provider configuration plus a static source-order contract.
+- **Verification:** Tests assert `403` without provider-setting names and zero
+  sender invocations; hostile mutations must fail.
+
+### U3. Document the Live Request Boundary
+
+- **Goal:** State which errors are available before and after authorization.
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, this plan.
+- **Approach:** Document authentication-first live behavior without implying
+  that the dial token protects dry-run requests.
+- **Verification:** The completed plan records actual commands and results.
+
+## Risks
+
+- Accidentally requiring authorization for dry runs would break the safe local
+  sample workflow.
+- Moving all validation before target checks could alter existing malformed
+  phone-number behavior.
+- Authorized callers must still receive actionable provider configuration
+  errors before any Twilio client is invoked.
+
+## Verification
+
+- `mvn -q -Dtest=MainTest test`: passed 32 focused unit and loopback tests.
+- `/tmp/engineering-bar/mutate-twilio-java-auth-order.sh`: rejected five
+  removed-authorization, dry-run overreach, wrong-token acceptance,
+  configuration-first, and disclosure mutations.
+- `git diff --check`: passed.
+- `make check`: passed compilation, 37 tests, package assembly, and the
+  scripted baseline.
+- `make -C /tmp/engineering-bar/twilio-java-auth-order-external/repo check`:
+  passed the same full gate from an external temporary repository path.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -35,9 +35,33 @@ for path in \
   "docs/plans/2026-06-10-dependencies-and-ci.md" \
   "docs/plans/2026-06-10-http-response-headers.md" \
   "docs/plans/2026-06-10-provider-failure-response.md" \
+  "docs/plans/2026-06-13-live-dial-authorization-order.md" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
+
+for authorization_order_contract in \
+  'if (sendLive && isBlank(TWILIO_DIAL_TOKEN))' \
+  'if (sendLive && !authorizedDialToken(TWILIO_DIAL_TOKEN, dialToken))' \
+  'liveDialAuthorizationPrecedesProviderConfigurationValidation' \
+  'liveDialRouteDoesNotDiscloseProviderConfigurationBeforeAuthorization' \
+  'assertFalse(unauthorized.body.contains("TWILIO_"))'; do
+  if ! grep -Fq -- "$authorization_order_contract" "$ROOT_DIR/src/main/java/org/example/Main.java" && \
+     ! grep -Fq -- "$authorization_order_contract" "$ROOT_DIR/src/test/java/org/example/MainTest.java"; then
+    printf '%s\n' "Live dial authorization-order contract is missing: $authorization_order_contract" >&2
+    exit 1
+  fi
+done
+
+authorization_line=$(grep -nF 'if (sendLive && !authorizedDialToken(TWILIO_DIAL_TOKEN, dialToken))' \
+  "$ROOT_DIR/src/main/java/org/example/Main.java" | cut -d: -f1)
+configuration_line=$(grep -nF 'String configurationError = callConfigurationError(' \
+  "$ROOT_DIR/src/main/java/org/example/Main.java" | cut -d: -f1)
+if [ -z "$authorization_line" ] || [ -z "$configuration_line" ] || \
+   [ "$authorization_line" -ge "$configuration_line" ]; then
+  printf '%s\n' "Live dial authorization must precede provider configuration validation." >&2
+  exit 1
+fi
 
 workflow_files=$(find "$ROOT_DIR/.github/workflows" -maxdepth 1 -type f -print | sort)
 if [ "$workflow_files" != "$WORKFLOW" ]; then

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -283,6 +283,13 @@ public class Main {
         }
 
         boolean sendLive = shouldSendLive(TWILIO_SEND_LIVE);
+        if (sendLive && isBlank(TWILIO_DIAL_TOKEN)) {
+            return new HttpResult(503, "Missing required configuration: TWILIO_DIAL_TOKEN");
+        }
+        if (sendLive && !authorizedDialToken(TWILIO_DIAL_TOKEN, dialToken)) {
+            return new HttpResult(403, "Invalid dial authorization token.");
+        }
+
         String configurationError = callConfigurationError(
                 accountSid,
                 authToken,
@@ -295,12 +302,6 @@ public class Main {
         }
         if (!sendLive) {
             return new HttpResult(200, dialMessage(phoneNumber, true));
-        }
-        if (isBlank(TWILIO_DIAL_TOKEN)) {
-            return new HttpResult(503, "Missing required configuration: TWILIO_DIAL_TOKEN");
-        }
-        if (!authorizedDialToken(TWILIO_DIAL_TOKEN, dialToken)) {
-            return new HttpResult(403, "Invalid dial authorization token.");
         }
 
         PhoneNumber to = new PhoneNumber(phoneNumber.trim());

--- a/src/test/java/org/example/MainTest.java
+++ b/src/test/java/org/example/MainTest.java
@@ -317,6 +317,88 @@ public class MainTest {
     }
 
     @Test
+    public void liveDialAuthorizationPrecedesProviderConfigurationValidation() {
+        String originalNumber = Main.twilioNumber;
+        String originalBaseUrl = Main.NGROK_BASE_URL;
+        String originalSendLive = Main.TWILIO_SEND_LIVE;
+        String originalDialToken = Main.TWILIO_DIAL_TOKEN;
+        String originalAccountSid = Main.accountSid;
+        String originalAuthToken = Main.authToken;
+        int[] senderCalls = {0};
+        try {
+            Main.twilioNumber = null;
+            Main.NGROK_BASE_URL = null;
+            Main.TWILIO_SEND_LIVE = "true";
+            Main.TWILIO_DIAL_TOKEN = "dial-secret";
+            Main.accountSid = null;
+            Main.authToken = null;
+
+            Main.HttpResult unauthorized = Main.dialPhone(
+                    "+15557654321",
+                    "wrong",
+                    (to, from, callbackUri) -> senderCalls[0]++
+            );
+            Main.HttpResult authorized = Main.dialPhone(
+                    "+15557654321",
+                    "dial-secret",
+                    (to, from, callbackUri) -> senderCalls[0]++
+            );
+
+            assertEquals(403, unauthorized.status);
+            assertEquals("Invalid dial authorization token.", unauthorized.body);
+            assertFalse(unauthorized.body.contains("TWILIO_"));
+            assertEquals(503, authorized.status);
+            assertTrue(authorized.body.contains("TWILIO_ACCOUNT_SID"));
+            assertEquals(0, senderCalls[0]);
+        } finally {
+            Main.twilioNumber = originalNumber;
+            Main.NGROK_BASE_URL = originalBaseUrl;
+            Main.TWILIO_SEND_LIVE = originalSendLive;
+            Main.TWILIO_DIAL_TOKEN = originalDialToken;
+            Main.accountSid = originalAccountSid;
+            Main.authToken = originalAuthToken;
+        }
+    }
+
+    @Test
+    public void liveDialRouteDoesNotDiscloseProviderConfigurationBeforeAuthorization() throws Exception {
+        String originalNumber = Main.twilioNumber;
+        String originalBaseUrl = Main.NGROK_BASE_URL;
+        String originalSendLive = Main.TWILIO_SEND_LIVE;
+        String originalDialToken = Main.TWILIO_DIAL_TOKEN;
+        String originalAccountSid = Main.accountSid;
+        String originalAuthToken = Main.authToken;
+        HttpServer server = Main.startServer(0);
+        try {
+            Main.twilioNumber = null;
+            Main.NGROK_BASE_URL = null;
+            Main.TWILIO_SEND_LIVE = "true";
+            Main.TWILIO_DIAL_TOKEN = "dial-secret";
+            Main.accountSid = null;
+            Main.authToken = null;
+
+            HttpResponse response = request(
+                    server.getAddress().getPort(),
+                    "POST",
+                    "/dial-phone",
+                    "number=%2B15557654321&dialToken=wrong"
+            );
+
+            assertEquals(403, response.status);
+            assertEquals("Invalid dial authorization token.", response.body);
+            assertFalse(response.body.contains("TWILIO_"));
+        } finally {
+            server.stop(0);
+            Main.twilioNumber = originalNumber;
+            Main.NGROK_BASE_URL = originalBaseUrl;
+            Main.TWILIO_SEND_LIVE = originalSendLive;
+            Main.TWILIO_DIAL_TOKEN = originalDialToken;
+            Main.accountSid = originalAccountSid;
+            Main.authToken = originalAuthToken;
+        }
+    }
+
+    @Test
     public void liveDialRejectsMissingOrIncorrectAuthorizationBeforeCallingTwilio() {
         String originalNumber = Main.twilioNumber;
         String originalBaseUrl = Main.NGROK_BASE_URL;


### PR DESCRIPTION
## Summary

Unauthenticated live dial requests can no longer distinguish missing Twilio credentials, sender configuration, or callback-origin setup. The existing dial token now gates those detailed errors, while dry runs remain credential-free and unauthenticated.

## Baseline

The live path validated provider configuration before checking the per-request dial token. A caller with an invalid token could therefore infer whether individual provider settings were missing or malformed even though no call was authorized.

## Improvements

- Check the configured and provided dial tokens before detailed provider validation in live mode.
- Preserve the existing missing-token `503` and invalid-token `403` responses.
- Preserve malformed-target handling and the unauthenticated dry-run workflow.
- Confirm authorized requests still validate provider configuration before the injected call sender can run.
- Enforce the source order in the scripted repository baseline.

## Validation

- `make check` passed compilation, 37 tests, package assembly, and baseline contracts.
- The same full gate passed from `/tmp/engineering-bar/twilio-java-auth-order-external/repo`.
- Five isolated authorization removal, dry-run overreach, wrong-token acceptance, configuration-first, and disclosure mutations were rejected.
- Direct and loopback tests confirm generic unauthorized responses and zero sender invocations.
- Sequential correctness, testing, maintainability, standards, security, reliability, adversarial, agent-native, and learnings review found no actionable issues.

## Risk

The dial token remains a shared secret rather than a per-user identity mechanism, and this change does not add rate limiting. No live Twilio call was attempted; provider behavior remains covered at the injected sender boundary.

## Follow-Ups

- Let hosted Check, CodeQL, and security integrations verify the exact branch head.
- Treat per-user authorization and rate limiting as separate changes if this sample becomes an internet-facing service.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
