### PR TITLE
Rate limit live dial attempts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+- Limited live dial requests to five attempts per process each minute before
+  body parsing or token comparison, with `429` and `Retry-After` responses.
+- Added deterministic window, route-ordering, response-header, and dry-run
+  independence coverage for the live-attempt boundary.
 - Authorized live dial requests before returning detailed Twilio credential,
   sender, or callback-origin configuration errors, while preserving
   unauthenticated dry runs.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   Live requests check that token before returning detailed Twilio credential,
   sender, or callback-origin configuration errors; dry runs remain
   unauthenticated and credential-free.
+- Tests limit the process to five live dial attempts per minute before form
+  parsing or token comparison. Exhausted requests return `429` with
+  `Retry-After: 60`; dry runs are not rate-limited.
 - Tests require provider failures to return a generic `502` without leaking
   exception details.
 - Tests require oversized dial forms to return `413` before parsing or dialing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,11 @@ Live `/dial-phone` requests require the separately configured
 `TWILIO_DIAL_TOKEN`. Use a high-entropy value, do not place it in URLs or source
 control, and rotate it if a submitted form or request log may have exposed it.
 
+The sample also permits at most five live dial attempts per process each
+minute, before form parsing or token comparison. This bounds token guessing and
+accidental call volume but is not a distributed control and does not replace
+Twilio account spend limits or deployment-level abuse protection.
+
 HTTP responses use `no-store`, framing denial, a no-referrer policy, a
 restrictive Content Security Policy, and disabled camera/geolocation/microphone
 capabilities. Keep these controls aligned with any future UI asset changes.

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Keep outbound calls in dry-run mode unless explicitly enabled
 - Require per-request authorization before any live dial attempt
 - Authorize live requests before disclosing provider configuration details
+- Bound live dial attempts before form parsing or authorization checks
 - Keep Twilio provider failure diagnostics out of HTTP responses
 - Keep every HTTP response non-cacheable, non-frameable, and constrained by a
   restrictive browser security policy

--- a/docs/plans/2026-06-13-live-dial-rate-limit.md
+++ b/docs/plans/2026-06-13-live-dial-rate-limit.md
@@ -1,0 +1,60 @@
+# Live Dial Rate Limit
+
+## Status: In Progress
+
+## Context
+
+The public `/dial-phone` route requires a shared token before a live Twilio
+call, but it currently accepts unlimited authorization attempts. That permits
+online token guessing and can amplify accidental or automated call attempts.
+
+## Requirements
+
+- R1. Limit live `/dial-phone` POST attempts before request-body parsing and
+  token comparison.
+- R2. Use a bounded, dependency-free, process-wide fixed window with no
+  attacker-controlled identity map.
+- R3. Permit at most five live attempts per 60-second window and return `429`
+  with a `Retry-After: 60` response when exhausted.
+- R4. Count authorized and unauthorized live attempts so the boundary also
+  limits accidental or automated call volume.
+- R5. Leave dry-run requests, static content, TwiML, method validation, and
+  content-type validation unchanged.
+- R6. Add deterministic unit and route coverage for exhaustion, reset, response
+  headers, pre-body ordering, and dry-run independence.
+- R7. Extend the scripted baseline and public security guidance so removing or
+  reordering the limiter fails `make check`.
+
+## Scope Boundaries
+
+- Do not add a distributed store, proxy-header trust, dependencies, retries, or
+  per-user identity.
+- Do not place a live Twilio call or change the shared-token format.
+- Do not claim that a per-process limit replaces provider-side spend controls.
+
+## Implementation Units
+
+### U1. Add the bounded live-attempt limiter
+
+- **Files:** `src/main/java/org/example/Main.java`
+- Implement a synchronized fixed window and enforce it before body parsing.
+
+### U2. Add deterministic regression coverage
+
+- **Files:** `src/test/java/org/example/MainTest.java`
+- Cover the exact allowance, rejection, reset boundary, `Retry-After`, ordering,
+  and dry-run behavior without credentials or network calls.
+
+### U3. Preserve repository contracts and guidance
+
+- **Files:** `scripts/check-baseline.sh`, `src/test/java/org/example/DocsPlansTest.java`,
+  `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Register the plan and document the operational and residual boundaries.
+
+## Verification
+
+- Focused Maven tests and full `make check`
+- External-directory and space-containing-path `make check`
+- Hostile mutations removing, weakening, bypassing, or reordering the limiter
+- Workflow YAML, XML, shell syntax, `git diff --check`, generated-artifact, and
+  focused secret review

--- a/docs/plans/2026-06-13-live-dial-rate-limit.md
+++ b/docs/plans/2026-06-13-live-dial-rate-limit.md
@@ -1,6 +1,6 @@
 # Live Dial Rate Limit
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -53,8 +53,11 @@ online token guessing and can amplify accidental or automated call attempts.
 
 ## Verification
 
-- Focused Maven tests and full `make check`
-- External-directory and space-containing-path `make check`
-- Hostile mutations removing, weakening, bypassing, or reordering the limiter
+- `mvn -q -Dtest=MainTest test` passed 35 focused tests.
+- Full local, external-directory, and space-containing-path `make check` runs
+  passed 40 tests, the package build, and the scripted baseline.
+- Nine hostile mutations covering raised limits, a longer window, removed or
+  dry-run-wide enforcement, missing retry metadata, wrong status, weakened
+  reset boundaries, late body ordering, and stale plan status were rejected.
 - Workflow YAML, XML, shell syntax, `git diff --check`, generated-artifact, and
-  focused secret review
+  focused secret reviews are included in final validation.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -36,9 +36,45 @@ for path in \
   "docs/plans/2026-06-10-http-response-headers.md" \
   "docs/plans/2026-06-10-provider-failure-response.md" \
   "docs/plans/2026-06-13-live-dial-authorization-order.md" \
+  "docs/plans/2026-06-13-live-dial-rate-limit.md" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
+
+for rate_limit_contract in \
+  'private static final int MAX_LIVE_DIAL_ATTEMPTS = 5;' \
+  'private static final long LIVE_DIAL_WINDOW_MILLIS = 60_000L;' \
+  '!LIVE_DIAL_RATE_LIMITER.tryAcquire(currentTimeMillis.getAsLong())' \
+  'exchange.getResponseHeaders().set("Retry-After", "60")' \
+  'sendResponse(exchange, 429, "text/plain; charset=utf-8", "Too many live dial attempts.")' \
+  'liveDialRateLimiterAllowsFiveAttemptsAndResetsAfterOneMinute' \
+  'liveDialRouteRateLimitsBeforeReadingAnotherFormBody' \
+  'dryRunRouteIgnoresExhaustedLiveDialRateLimit'; do
+  if ! grep -Fq -- "$rate_limit_contract" "$ROOT_DIR/src/main/java/org/example/Main.java" && \
+     ! grep -Fq -- "$rate_limit_contract" "$ROOT_DIR/src/test/java/org/example/MainTest.java"; then
+    printf '%s\n' "Live dial rate-limit contract is missing: $rate_limit_contract" >&2
+    exit 1
+  fi
+done
+
+python3 - "$ROOT_DIR/src/main/java/org/example/Main.java" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+markers = (
+    'if (!isFormContentType(contentType))',
+    '&& !LIVE_DIAL_RATE_LIMITER.tryAcquire(currentTimeMillis.getAsLong()))',
+    'byte[] requestBody = readRequestBody(exchange);',
+    'dialToken = formValue(requestBody, "dialToken");',
+)
+positions = tuple(source.index(marker) for marker in markers)
+if positions != tuple(sorted(positions)):
+    raise SystemExit(
+        "Live dial rate limiting must follow media-type validation and precede "
+        "request-body parsing and token extraction."
+    )
+PY
 
 for authorization_order_contract in \
   'if (sendLive && isBlank(TWILIO_DIAL_TOKEN))' \

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -22,6 +22,7 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.LongSupplier;
 import java.util.regex.Pattern;
 
 public class Main {
@@ -33,6 +34,11 @@ public class Main {
     static String TWILIO_DIAL_TOKEN = System.getenv("TWILIO_DIAL_TOKEN");
     private static final Pattern E164_PHONE_NUMBER = Pattern.compile("^\\+[1-9]\\d{1,14}$");
     private static final int MAX_FORM_BYTES = 8 * 1024;
+    private static final int MAX_LIVE_DIAL_ATTEMPTS = 5;
+    private static final long LIVE_DIAL_WINDOW_MILLIS = 60_000L;
+    private static final LiveDialRateLimiter LIVE_DIAL_RATE_LIMITER =
+            new LiveDialRateLimiter(MAX_LIVE_DIAL_ATTEMPTS, LIVE_DIAL_WINDOW_MILLIS);
+    static LongSupplier currentTimeMillis = System::currentTimeMillis;
     interface CallSender {
         void create(PhoneNumber to, PhoneNumber from, URI callbackUri);
     }
@@ -230,6 +236,12 @@ public class Main {
             sendResponse(exchange, 415, "text/plain; charset=utf-8", "Expected form data.");
             return;
         }
+        if (shouldSendLive(TWILIO_SEND_LIVE)
+                && !LIVE_DIAL_RATE_LIMITER.tryAcquire(currentTimeMillis.getAsLong())) {
+            exchange.getResponseHeaders().set("Retry-After", "60");
+            sendResponse(exchange, 429, "text/plain; charset=utf-8", "Too many live dial attempts.");
+            return;
+        }
         String phoneNumber;
         String dialToken;
         try {
@@ -398,6 +410,42 @@ public class Main {
             this.status = status;
             this.body = body;
         }
+    }
+
+    static final class LiveDialRateLimiter {
+        private final int maxAttempts;
+        private final long windowMillis;
+        private long windowStartedAt = Long.MIN_VALUE;
+        private int attempts;
+
+        LiveDialRateLimiter(int maxAttempts, long windowMillis) {
+            this.maxAttempts = maxAttempts;
+            this.windowMillis = windowMillis;
+        }
+
+        synchronized boolean tryAcquire(long nowMillis) {
+            if (windowStartedAt == Long.MIN_VALUE
+                    || nowMillis < windowStartedAt
+                    || nowMillis - windowStartedAt >= windowMillis) {
+                windowStartedAt = nowMillis;
+                attempts = 0;
+            }
+            if (attempts >= maxAttempts) {
+                return false;
+            }
+            attempts++;
+            return true;
+        }
+
+        synchronized void reset() {
+            windowStartedAt = Long.MIN_VALUE;
+            attempts = 0;
+        }
+    }
+
+    static void resetLiveDialRateLimit() {
+        LIVE_DIAL_RATE_LIMITER.reset();
+        currentTimeMillis = System::currentTimeMillis;
     }
 
     private static final class RequestTooLargeException extends Exception {

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -28,6 +28,8 @@ public class DocsPlansTest {
             DOCS_PLANS.resolve("2026-06-10-dependencies-and-ci.md");
     private static final Path HTTP_RESPONSE_HEADERS_PLAN =
             DOCS_PLANS.resolve("2026-06-10-http-response-headers.md");
+    private static final Path LIVE_DIAL_RATE_LIMIT_PLAN =
+            DOCS_PLANS.resolve("2026-06-13-live-dial-rate-limit.md");
 
     @Test
     public void canonicalPlanIsCompletedAndVerified() throws IOException {
@@ -52,6 +54,7 @@ public class DocsPlansTest {
                 plans.contains(DEPENDENCIES_AND_CI_PLAN)
         );
         assertTrue("HTTP response headers plan must exist", plans.contains(HTTP_RESPONSE_HEADERS_PLAN));
+        assertTrue("live dial rate-limit plan must exist", plans.contains(LIVE_DIAL_RATE_LIMIT_PLAN));
 
         for (Path plan : plans) {
             String text = new String(Files.readAllBytes(plan), StandardCharsets.UTF_8);

--- a/src/test/java/org/example/MainTest.java
+++ b/src/test/java/org/example/MainTest.java
@@ -399,6 +399,89 @@ public class MainTest {
     }
 
     @Test
+    public void liveDialRateLimiterAllowsFiveAttemptsAndResetsAfterOneMinute() {
+        Main.LiveDialRateLimiter limiter = new Main.LiveDialRateLimiter(5, 60_000L);
+
+        for (int attempt = 0; attempt < 5; attempt++) {
+            assertTrue(limiter.tryAcquire(1_000L));
+        }
+        assertFalse(limiter.tryAcquire(60_999L));
+        assertTrue(limiter.tryAcquire(61_000L));
+    }
+
+    @Test
+    public void liveDialRouteRateLimitsBeforeReadingAnotherFormBody() throws Exception {
+        String originalSendLive = Main.TWILIO_SEND_LIVE;
+        String originalDialToken = Main.TWILIO_DIAL_TOKEN;
+        Main.resetLiveDialRateLimit();
+        Main.currentTimeMillis = () -> 1_000L;
+        HttpServer server = Main.startServer(0);
+        try {
+            Main.TWILIO_SEND_LIVE = "true";
+            Main.TWILIO_DIAL_TOKEN = "dial-secret";
+            int port = server.getAddress().getPort();
+            for (int attempt = 0; attempt < 5; attempt++) {
+                String token = attempt == 0 ? "dial-secret" : "wrong";
+                HttpResponse response = request(
+                        port,
+                        "POST",
+                        "/dial-phone",
+                        "number=%2B15557654321&dialToken=" + token
+                );
+                assertEquals(attempt == 0 ? 503 : 403, response.status);
+            }
+
+            String oversizedBody = "number=%2B15557654321&dialToken=" + repeat("x", 9 * 1024);
+            HttpResponse limited = request(port, "POST", "/dial-phone", oversizedBody);
+
+            assertEquals(429, limited.status);
+            assertEquals("60", limited.retryAfter);
+            assertEquals("Too many live dial attempts.", limited.body);
+        } finally {
+            server.stop(0);
+            Main.TWILIO_SEND_LIVE = originalSendLive;
+            Main.TWILIO_DIAL_TOKEN = originalDialToken;
+            Main.resetLiveDialRateLimit();
+        }
+    }
+
+    @Test
+    public void dryRunRouteIgnoresExhaustedLiveDialRateLimit() throws Exception {
+        String originalNumber = Main.twilioNumber;
+        String originalBaseUrl = Main.NGROK_BASE_URL;
+        String originalSendLive = Main.TWILIO_SEND_LIVE;
+        Main.resetLiveDialRateLimit();
+        Main.currentTimeMillis = () -> 1_000L;
+        HttpServer server = Main.startServer(0);
+        try {
+            Main.twilioNumber = "+15551234567";
+            Main.NGROK_BASE_URL = "https://example.ngrok.io";
+            Main.TWILIO_SEND_LIVE = "true";
+            int port = server.getAddress().getPort();
+            for (int attempt = 0; attempt < 5; attempt++) {
+                request(port, "POST", "/dial-phone", "number=%2B15557654321");
+            }
+
+            Main.TWILIO_SEND_LIVE = "false";
+            HttpResponse dryRun = request(
+                    port,
+                    "POST",
+                    "/dial-phone",
+                    "number=%2B15557654321"
+            );
+
+            assertEquals(200, dryRun.status);
+            assertTrue(dryRun.body.startsWith("Dry run:"));
+        } finally {
+            server.stop(0);
+            Main.twilioNumber = originalNumber;
+            Main.NGROK_BASE_URL = originalBaseUrl;
+            Main.TWILIO_SEND_LIVE = originalSendLive;
+            Main.resetLiveDialRateLimit();
+        }
+    }
+
+    @Test
     public void liveDialRejectsMissingOrIncorrectAuthorizationBeforeCallingTwilio() {
         String originalNumber = Main.twilioNumber;
         String originalBaseUrl = Main.NGROK_BASE_URL;
@@ -575,6 +658,7 @@ public class MainTest {
                 connection.getHeaderField("Permissions-Policy"),
                 connection.getHeaderField("Referrer-Policy"),
                 connection.getHeaderField("X-Frame-Options"),
+                connection.getHeaderField("Retry-After"),
                 responseBody
         );
         connection.disconnect();
@@ -601,6 +685,7 @@ public class MainTest {
         final String permissionsPolicy;
         final String referrerPolicy;
         final String frameOptions;
+        final String retryAfter;
         final String body;
 
         HttpResponse(
@@ -612,6 +697,7 @@ public class MainTest {
                 String permissionsPolicy,
                 String referrerPolicy,
                 String frameOptions,
+                String retryAfter,
                 String body
         ) {
             this.status = status;
@@ -622,7 +708,16 @@ public class MainTest {
             this.permissionsPolicy = permissionsPolicy;
             this.referrerPolicy = referrerPolicy;
             this.frameOptions = frameOptions;
+            this.retryAfter = retryAfter;
             this.body = body;
         }
+    }
+
+    private static String repeat(String value, int count) {
+        StringBuilder builder = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            builder.append(value);
+        }
+        return builder.toString();
     }
 }


### PR DESCRIPTION
## Summary

- limit live `/dial-phone` requests to five attempts per process each minute
- enforce the quota before request-body parsing and authorization-token extraction
- return `429` with `Retry-After: 60` while leaving dry runs unlimited

## Baseline

- live dial attempts had no process-local per-minute quota
- request parsing and authorization-token extraction occurred before the new quota enforcement point

## Improvements

- add deterministic and loopback coverage plus fail-closed baseline enforcement
- Compound Engineering review found no actionable correctness, security, testing, maintainability, or project-standards issues

## Validation

- focused `MainTest`: 35 passed
- local, external-directory, and space-containing-path `make check`: 40 passed each
- Maven package build and scripted baseline passed
- nine hostile mutations rejected
- workflow YAML, Maven XML, shell syntax, diff, generated-artifact, and focused secret checks passed
- no live Twilio call was made

## Risk

- the quota is intentionally process-local; horizontally scaled deployments still need upstream or shared enforcement
- live attempts beyond five per process each minute now receive `429` with `Retry-After: 60`, while dry runs remain unlimited
- this is a stacked pull request based on PR #18 (`lfg/twilio-java-auth-order-20260613`), so its merge order must be preserved

## Follow-Ups

This PR builds on `lfg/twilio-java-auth-order-20260613` (PR #18).
