### PR TITLE
fix: reject ambiguous dial forms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Rejected duplicate phone/token fields and malformed percent encoding with a
+  generic `400` before dial authorization or provider configuration.
 - Limited live dial requests to five attempts per process each minute before
   body parsing or token comparison, with `429` and `Retry-After` responses.
 - Added deterministic window, route-ordering, response-header, and dry-run

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   checked-in form marks the phone number field as required before submission.
 - Twilio SDK failures return a generic `502` response without exposing provider
   diagnostics, credentials, or request metadata.
+- Duplicate `number` or `dialToken` fields and malformed percent encoding are
+  rejected with a generic `400` before authorization or provider setup; unknown
+  form fields remain ignored for browser compatibility.
 - `NGROK_URL` must be a valid HTTPS origin URL with a host, without path,
   query, fragment, or userinfo, before the app builds a TwiML callback URL.
 - The `/twiml` route returns TwiML XML with an explicit `application/xml`
@@ -99,6 +102,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Tests require provider failures to return a generic `502` without leaking
   exception details.
 - Tests require oversized dial forms to return `413` before parsing or dialing.
+- Tests require one-pass dial-form parsing to reject duplicate relevant fields
+  and malformed percent encoding before authorization or provider setup.
 - Tests require `/dial-phone` to accept the exact form media type, including
   case-insensitive parameterized variants, while rejecting missing, unrelated,
   and spoofed-prefix content types with `415`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,10 @@ minute, before form parsing or token comparison. This bounds token guessing and
 accidental call volume but is not a distributed control and does not replace
 Twilio account spend limits or deployment-level abuse protection.
 
+The dial form rejects duplicate phone-number or authorization-token fields and
+malformed percent encoding before authorization or provider configuration.
+Unknown fields are ignored, but relevant fields must be unique and decodable.
+
 HTTP responses use `no-store`, framing denial, a no-referrer policy, a
 restrictive Content Security Policy, and disabled camera/geolocation/microphone
 capabilities. Keep these controls aligned with any future UI asset changes.

--- a/VISION.md
+++ b/VISION.md
@@ -32,6 +32,8 @@ Priority:
 - Require per-request authorization before any live dial attempt
 - Authorize live requests before disclosing provider configuration details
 - Bound live dial attempts before form parsing or authorization checks
+- Reject duplicate or malformed security-relevant dial form fields before
+  authorization and provider configuration
 - Keep Twilio provider failure diagnostics out of HTTP responses
 - Keep every HTTP response non-cacheable, non-frameable, and constrained by a
   restrictive browser security policy

--- a/docs/plans/2026-06-13-strict-dial-form-parsing.md
+++ b/docs/plans/2026-06-13-strict-dial-form-parsing.md
@@ -1,6 +1,6 @@
 # Strict Dial Form Parsing
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -75,3 +75,31 @@ route ordering, tests, docs, and completed verification evidence.
   alter authorization and provider-configuration response precedence.
 - Do not reject unknown fields, add multipart/JSON support, change dependencies,
   or make live Twilio calls.
+
+## Work Completed
+
+- Replaced independent first-match extraction with one bounded `DialForm`
+  parsing pass for `number` and `dialToken`.
+- Rejected duplicate relevant fields, malformed relevant field names or values,
+  and missing separators with a generic HTTP 400 response.
+- Preserved unknown-field compatibility and the existing pre-body live rate
+  limit, then passed the parsed values into the unchanged authorization and
+  provider configuration path.
+- Added loopback integration coverage plus fail-closed source, ordering,
+  documentation, and completed-plan contracts.
+
+## Verification
+
+- The focused `MainTest` class passed 37 tests, including duplicate number,
+  duplicate token, malformed name/value, generic response, live configuration
+  nondisclosure, and accepted unknown-field cases.
+- Full repository and external-working-directory `make check` passed under
+  explicit hard timeouts, including compilation, all JUnit tests, packaging,
+  dependency/security baseline checks, and the executable jar assembly.
+- Focused hostile mutations for each duplicate guard, malformed decoding,
+  parser and rate-limit ordering, unknown-field compatibility, response text,
+  route tests, documentation, and plan status were rejected.
+- Maven XML, workflow YAML, shell syntax, Java compilation, intended-path,
+  generated-artifact, `git diff --check`, and changed-line secret audits passed
+  before shipment.
+- No Twilio credentials, live calls, or external callback requests were used.

--- a/docs/plans/2026-06-13-strict-dial-form-parsing.md
+++ b/docs/plans/2026-06-13-strict-dial-form-parsing.md
@@ -1,0 +1,77 @@
+# Strict Dial Form Parsing
+
+## Status: Planned
+
+## Context
+
+The dial route parses `number` and `dialToken` independently and returns the
+first matching form value. Duplicate security-relevant fields are therefore
+ambiguous, while malformed percent encoding collapses into a missing value
+instead of being identified as an invalid form submission.
+
+## Priority
+
+Parse the bounded form once and reject duplicate or malformed relevant fields
+before authorization, provider configuration, or call setup. This addresses
+the roadmap's malformed-form integration gap without broadening the endpoint.
+
+## Requirements
+
+- R1. Parse `number` and `dialToken` from one bounded UTF-8 form body pass.
+- R2. Reject duplicate `number` fields with HTTP 400.
+- R3. Reject duplicate `dialToken` fields with HTTP 400.
+- R4. Reject malformed percent encoding in a relevant field name or value with
+  HTTP 400.
+- R5. Keep unknown form fields ignored so ordinary browser submissions remain
+  compatible.
+- R6. Perform strict parsing before dial authorization, provider configuration,
+  or Twilio client setup while preserving the existing pre-body rate limit.
+- R7. Preserve method, media type, body-size, E.164, callback, authorization,
+  provider-error, response-header, and dry-run safeguards.
+- R8. Add route-level tests, portable contracts, hostile mutations, and
+  completed maintenance documentation.
+
+## Implementation Units
+
+### Parse relevant form fields strictly
+
+**Files:** `src/main/java/org/example/Main.java`
+
+Replace repeated first-match extraction with a small parsed result that tracks
+the two accepted fields. Decode names before classification, decode relevant
+values exactly once, and throw a dedicated invalid-form exception for malformed
+encoding or duplicate accepted fields.
+
+### Exercise route behavior
+
+**Files:** `src/test/java/org/example/MainTest.java`
+
+Add integration cases for duplicate phone numbers, duplicate dial tokens,
+malformed relevant names and values, accepted unknown fields, uniform response
+text, and no provider invocation.
+
+### Preserve contracts and records
+
+**Files:** `scripts/check-baseline.sh`, `README.md`, `SECURITY.md`, `VISION.md`,
+`CHANGES.md`, `docs/plans/2026-06-13-strict-dial-form-parsing.md`
+
+Require single-pass parsing, both duplicate guards, malformed-encoding failure,
+route ordering, tests, docs, and completed verification evidence.
+
+## Verification Plan
+
+- focused strict-form and authorization route tests
+- full Maven `make check` and external-working-directory gate under hard
+  timeouts
+- hostile mutations for each duplicate guard, malformed name/value handling,
+  parser ordering, unknown-field compatibility, provider-call prevention,
+  documentation, and plan status
+- Maven dependency consistency/audit baseline, XML/shell/Java syntax,
+  intended-path, generated-artifact, whitespace, and changed-line secret audits
+
+## Scope Boundaries
+
+- Do not change rate-limit thresholds, parse the body before rate limiting, or
+  alter authorization and provider-configuration response precedence.
+- Do not reject unknown fields, add multipart/JSON support, change dependencies,
+  or make live Twilio calls.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -37,6 +37,7 @@ for path in \
   "docs/plans/2026-06-10-provider-failure-response.md" \
   "docs/plans/2026-06-13-live-dial-authorization-order.md" \
   "docs/plans/2026-06-13-live-dial-rate-limit.md" \
+  "docs/plans/2026-06-13-strict-dial-form-parsing.md" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
@@ -66,7 +67,8 @@ markers = (
     'if (!isFormContentType(contentType))',
     '&& !LIVE_DIAL_RATE_LIMITER.tryAcquire(currentTimeMillis.getAsLong()))',
     'byte[] requestBody = readRequestBody(exchange);',
-    'dialToken = formValue(requestBody, "dialToken");',
+    'dialForm = parseDialForm(requestBody);',
+    'HttpResult result = dialPhone(dialForm.phoneNumber, dialForm.dialToken);',
 )
 positions = tuple(source.index(marker) for marker in markers)
 if positions != tuple(sorted(positions)):
@@ -74,6 +76,54 @@ if positions != tuple(sorted(positions)):
         "Live dial rate limiting must follow media-type validation and precede "
         "request-body parsing and token extraction."
     )
+PY
+
+for strict_form_contract in \
+  'private static DialForm parseDialForm(byte[] body) throws InvalidFormException' \
+  'String name = decodeFormComponent(parts[0]);' \
+  'if (name == null)' \
+  'if (!"number".equals(name) && !"dialToken".equals(name))' \
+  'String value = decodeFormComponent(parts[1]);' \
+  'if (value == null)' \
+  'if (phoneNumber != null)' \
+  'if (dialToken != null)' \
+  'throw new InvalidFormException();' \
+  'sendResponse(exchange, 400, "text/plain; charset=utf-8", "Invalid form submission.")' \
+  'dialPhoneRouteRejectsAmbiguousOrMalformedRelevantFormFields' \
+  'dialPhoneRouteIgnoresUnknownFormFields'; do
+  if ! grep -Fq -- "$strict_form_contract" "$ROOT_DIR/src/main/java/org/example/Main.java" && \
+     ! grep -Fq -- "$strict_form_contract" "$ROOT_DIR/src/test/java/org/example/MainTest.java"; then
+    printf '%s\n' "Strict dial form contract is missing: $strict_form_contract" >&2
+    exit 1
+  fi
+done
+
+if grep -Fq 'formValue(' "$ROOT_DIR/src/main/java/org/example/Main.java"; then
+  printf '%s\n' "Dial form fields must be parsed together instead of first-match extraction." >&2
+  exit 1
+fi
+
+python3 - "$ROOT_DIR/src/main/java/org/example/Main.java" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+parser = re.search(
+    r"private static DialForm parseDialForm\(byte\[] body\) throws InvalidFormException \{"
+    r"(?P<body>.*?)\n    \}",
+    source,
+    re.DOTALL,
+)
+if parser is None:
+    raise SystemExit("Strict dial form parser body must remain explicit.")
+body = parser.group("body")
+unknown = re.search(
+    r'if \(!"number"\.equals\(name\) && !"dialToken"\.equals\(name\)\) \{\s*continue;\s*\}',
+    body,
+)
+if unknown is None:
+    raise SystemExit("Unknown dial form fields must remain ignored.")
 PY
 
 for authorization_order_contract in \

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -242,17 +242,18 @@ public class Main {
             sendResponse(exchange, 429, "text/plain; charset=utf-8", "Too many live dial attempts.");
             return;
         }
-        String phoneNumber;
-        String dialToken;
+        DialForm dialForm;
         try {
             byte[] requestBody = readRequestBody(exchange);
-            phoneNumber = formValue(requestBody, "number");
-            dialToken = formValue(requestBody, "dialToken");
+            dialForm = parseDialForm(requestBody);
         } catch (RequestTooLargeException requestTooLargeException) {
             sendResponse(exchange, 413, "text/plain; charset=utf-8", "Form submission is too large.");
             return;
+        } catch (InvalidFormException invalidFormException) {
+            sendResponse(exchange, 400, "text/plain; charset=utf-8", "Invalid form submission.");
+            return;
         }
-        HttpResult result = dialPhone(phoneNumber, dialToken);
+        HttpResult result = dialPhone(dialForm.phoneNumber, dialForm.dialToken);
         sendResponse(exchange, result.status, "text/plain; charset=utf-8", result.body);
     }
 
@@ -359,15 +360,39 @@ public class Main {
         }
     }
 
-    private static String formValue(byte[] body, String expectedName) {
+    private static DialForm parseDialForm(byte[] body) throws InvalidFormException {
         String form = new String(body, StandardCharsets.UTF_8);
+        String phoneNumber = null;
+        String dialToken = null;
         for (String pair : form.split("&")) {
             String[] parts = pair.split("=", 2);
-            if (parts.length == 2 && expectedName.equals(decodeFormComponent(parts[0]))) {
-                return decodeFormComponent(parts[1]);
+            String name = decodeFormComponent(parts[0]);
+            if (name == null) {
+                throw new InvalidFormException();
+            }
+            if (!"number".equals(name) && !"dialToken".equals(name)) {
+                continue;
+            }
+            if (parts.length != 2) {
+                throw new InvalidFormException();
+            }
+            String value = decodeFormComponent(parts[1]);
+            if (value == null) {
+                throw new InvalidFormException();
+            }
+            if ("number".equals(name)) {
+                if (phoneNumber != null) {
+                    throw new InvalidFormException();
+                }
+                phoneNumber = value;
+            } else {
+                if (dialToken != null) {
+                    throw new InvalidFormException();
+                }
+                dialToken = value;
             }
         }
-        return null;
+        return new DialForm(phoneNumber, dialToken);
     }
 
     private static String decodeFormComponent(String value) {
@@ -412,6 +437,16 @@ public class Main {
         }
     }
 
+    private static final class DialForm {
+        final String phoneNumber;
+        final String dialToken;
+
+        DialForm(String phoneNumber, String dialToken) {
+            this.phoneNumber = phoneNumber;
+            this.dialToken = dialToken;
+        }
+    }
+
     static final class LiveDialRateLimiter {
         private final int maxAttempts;
         private final long windowMillis;
@@ -449,6 +484,9 @@ public class Main {
     }
 
     private static final class RequestTooLargeException extends Exception {
+    }
+
+    private static final class InvalidFormException extends Exception {
     }
 
     public static void main(String[] args) throws IOException {

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -30,6 +30,8 @@ public class DocsPlansTest {
             DOCS_PLANS.resolve("2026-06-10-http-response-headers.md");
     private static final Path LIVE_DIAL_RATE_LIMIT_PLAN =
             DOCS_PLANS.resolve("2026-06-13-live-dial-rate-limit.md");
+    private static final Path STRICT_DIAL_FORM_PLAN =
+            DOCS_PLANS.resolve("2026-06-13-strict-dial-form-parsing.md");
 
     @Test
     public void canonicalPlanIsCompletedAndVerified() throws IOException {
@@ -55,6 +57,7 @@ public class DocsPlansTest {
         );
         assertTrue("HTTP response headers plan must exist", plans.contains(HTTP_RESPONSE_HEADERS_PLAN));
         assertTrue("live dial rate-limit plan must exist", plans.contains(LIVE_DIAL_RATE_LIMIT_PLAN));
+        assertTrue("strict dial form plan must exist", plans.contains(STRICT_DIAL_FORM_PLAN));
 
         for (Path plan : plans) {
             String text = new String(Files.readAllBytes(plan), StandardCharsets.UTF_8);

--- a/src/test/java/org/example/MainTest.java
+++ b/src/test/java/org/example/MainTest.java
@@ -250,6 +250,77 @@ public class MainTest {
     }
 
     @Test
+    public void dialPhoneRouteRejectsAmbiguousOrMalformedRelevantFormFields() throws Exception {
+        String originalNumber = Main.twilioNumber;
+        String originalBaseUrl = Main.NGROK_BASE_URL;
+        String originalSendLive = Main.TWILIO_SEND_LIVE;
+        String originalDialToken = Main.TWILIO_DIAL_TOKEN;
+        String originalAccountSid = Main.accountSid;
+        String originalAuthToken = Main.authToken;
+        Main.resetLiveDialRateLimit();
+        HttpServer server = Main.startServer(0);
+        try {
+            Main.twilioNumber = "+15551234567";
+            Main.NGROK_BASE_URL = "https://example.ngrok.io";
+            Main.TWILIO_SEND_LIVE = "true";
+            Main.TWILIO_DIAL_TOKEN = "dial-secret";
+            Main.accountSid = null;
+            Main.authToken = null;
+            int port = server.getAddress().getPort();
+
+            String[] invalidBodies = {
+                    "number=%2B15557654321&number=%2B15550000000&dialToken=dial-secret",
+                    "number=%2B15557654321&dialToken=dial-secret&dialToken=wrong",
+                    "num%ZZber=%2B15557654321&dialToken=dial-secret",
+                    "number=%ZZ&dialToken=dial-secret"
+            };
+            for (String body : invalidBodies) {
+                HttpResponse response = request(port, "POST", "/dial-phone", body);
+                assertEquals(400, response.status);
+                assertEquals("Invalid form submission.", response.body);
+                assertFalse(response.body.contains("TWILIO_"));
+            }
+        } finally {
+            server.stop(0);
+            Main.twilioNumber = originalNumber;
+            Main.NGROK_BASE_URL = originalBaseUrl;
+            Main.TWILIO_SEND_LIVE = originalSendLive;
+            Main.TWILIO_DIAL_TOKEN = originalDialToken;
+            Main.accountSid = originalAccountSid;
+            Main.authToken = originalAuthToken;
+            Main.resetLiveDialRateLimit();
+        }
+    }
+
+    @Test
+    public void dialPhoneRouteIgnoresUnknownFormFields() throws Exception {
+        String originalNumber = Main.twilioNumber;
+        String originalBaseUrl = Main.NGROK_BASE_URL;
+        String originalSendLive = Main.TWILIO_SEND_LIVE;
+        HttpServer server = Main.startServer(0);
+        try {
+            Main.twilioNumber = "+15551234567";
+            Main.NGROK_BASE_URL = "https://example.ngrok.io";
+            Main.TWILIO_SEND_LIVE = "false";
+
+            HttpResponse response = request(
+                    server.getAddress().getPort(),
+                    "POST",
+                    "/dial-phone",
+                    "number=%2B15557654321&submit=Dial"
+            );
+
+            assertEquals(200, response.status);
+            assertTrue(response.body.startsWith("Dry run: would dial "));
+        } finally {
+            server.stop(0);
+            Main.twilioNumber = originalNumber;
+            Main.NGROK_BASE_URL = originalBaseUrl;
+            Main.TWILIO_SEND_LIVE = originalSendLive;
+        }
+    }
+
+    @Test
     public void rootRouteServesTheUpdatedForm() throws Exception {
         HttpServer server = Main.startServer(0);
         try {


### PR DESCRIPTION
## Summary

Reject ambiguous or malformed security-relevant dial form fields before authorization or provider configuration is evaluated.

## Baseline

This is stacked on `lfg/twilio-java-dial-rate-limit-20260613`, preserving its pre-body live dial rate limit and existing authorization behavior.

## Improvements

- Parse `number` and `dialToken` together in one bounded pass.
- Reject duplicate relevant fields and malformed relevant names or values with a generic HTTP 400 response.
- Continue ignoring unknown form fields for compatibility.
- Keep rate limiting before request-body reading and parsing.
- Add integration tests and mutation-sensitive static contracts for the parser and route ordering.

## Validation

- `MainTest`: 37 tests passed.
- Full repository `make check`: 42 tests passed, compile/package/checker passed.
- External-working-directory `make check`: passed.
- Ten hostile mutations were rejected.
- Shell syntax, Java compilation, diff whitespace, artifact, intended-path, and credential-shaped literal audits passed.

## Risk

Malformed or duplicate relevant fields now fail closed. Unknown fields remain accepted, and successful requests continue through the existing dial behavior.

## Follow-Ups

Hosted CI and code scanning are tracked against the exact PR head.

## Post-Deploy

No deployment action is required. This change does not add dependencies or configuration.
