### PR TITLE
fix: protect Make root from overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build check lint test verify
 
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 MVN ?= mvn
 
 lint:

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,70 @@
+# Make Root Override Protection
+
+## Status: Planned
+
+## Context
+
+The Makefile derives `ROOT` from its own location so targets work when invoked
+outside the checkout. GNU Make command-line assignments still take precedence
+over an ordinary `:=` assignment, allowing `make ROOT=/other/path check` to
+redirect builds and the repository guard away from the intended checkout.
+
+## Priority
+
+Protect the repository root as an internal invariant while preserving the
+documented `MVN` tool override. This keeps every Make target anchored to the
+same reviewed sources and verification script.
+
+## Requirements
+
+- R1. Define `ROOT` with GNU Make's `override` directive and derive it from the
+  loaded Makefile path.
+- R2. Keep `MVN ?= mvn` so callers and hosted jobs can select a Maven binary.
+- R3. Prove `lint`, `test`, `build`, and `check` ignore a hostile command-line
+  `ROOT` assignment.
+- R4. Preserve successful invocation from a working directory outside the
+  checkout.
+- R5. Add portable static contracts and hostile mutations for the protected
+  root assignment without changing application behavior or dependencies.
+- R6. Record completed local verification before shipment.
+
+## Implementation Units
+
+### Protect the internal Make root
+
+**Files:** `Makefile`
+
+Change the existing Makefile-derived assignment to `override ROOT := ...` and
+leave the `MVN` override contract unchanged.
+
+### Enforce the contract
+
+**Files:** `scripts/check-baseline.sh`, `src/test/java/org/example/DocsPlansTest.java`
+
+Require the exact protected assignment and reject weaker ordinary, recursive,
+environment-derived, or current-directory root definitions.
+
+### Record verification
+
+**Files:** `docs/plans/2026-06-14-make-root-override-protection.md`
+
+Mark the plan completed only after focused tests, the full gate, external and
+hostile-root invocations, mutations, and repository audits pass.
+
+## Verification Plan
+
+- focused `DocsPlansTest`
+- full `make check` with a hard timeout
+- external-working-directory `make -C <checkout> check`
+- hostile `make -C <checkout> ROOT=<empty-directory> check`
+- mutations removing `override`, restoring `CURDIR`, changing to recursive
+  assignment, weakening static tests, or removing plan completion evidence
+- `git diff --check`, intended-path, generated-artifact, and changed-line
+  secret audits
+
+## Scope Boundaries
+
+- Do not remove the `MVN` override or pin a machine-specific Maven path.
+- Do not alter Java sources, runtime behavior, dependencies, workflow coverage,
+  or live Twilio safeguards.
+- Do not merge or close any stacked pull request without owner authorization.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,6 +1,6 @@
 # Make Root Override Protection
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -68,3 +68,29 @@ hostile-root invocations, mutations, and repository audits pass.
 - Do not alter Java sources, runtime behavior, dependencies, workflow coverage,
   or live Twilio safeguards.
 - Do not merge or close any stacked pull request without owner authorization.
+
+## Work Completed
+
+- Protected the Makefile-derived repository root with GNU Make's `override`
+  directive while preserving the configurable Maven command.
+- Added shell and JUnit contracts for the exact protected assignment, the
+  Makefile-derived path, and the Maven override.
+- Added the plan to the repository's required maintenance-document set.
+
+## Verification
+
+- The focused `DocsPlansTest#checkGateRunsScriptedBaseline` test passed on
+  Amazon Corretto 8 with Maven 3.6.3.
+- A hostile `make ROOT=<empty-directory> lint` invocation ignored the supplied
+  root and compiled the intended checkout.
+- Full `make check`, external-working-directory `make -C <checkout> check`, and
+  hostile `make -C <checkout> ROOT=<empty-directory> check` each passed under
+  a 300-second timeout, including compilation, 42 JUnit tests, packaging, and
+  the scripted baseline.
+- Eight hostile mutations were rejected: removing `override`, using `CURDIR`,
+  changing to recursive assignment, deriving from the first loaded Makefile,
+  removing Maven configurability, weakening either static guard, and removing
+  completed plan status.
+- Makefile, shell, Java, intended-path, generated-artifact, `git diff --check`,
+  and changed-line secret audits passed before shipment.
+- No Twilio credentials, live calls, or external callback requests were used.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -38,9 +38,21 @@ for path in \
   "docs/plans/2026-06-13-live-dial-authorization-order.md" \
   "docs/plans/2026-06-13-live-dial-rate-limit.md" \
   "docs/plans/2026-06-13-strict-dial-form-parsing.md" \
+  "docs/plans/2026-06-14-make-root-override-protection.md" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
+
+make_root='override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))'
+if ! grep -Fxq -- "$make_root" "$MAKEFILE"; then
+  printf '%s\n' "Makefile ROOT must be protected and derived from the loaded Makefile." >&2
+  exit 1
+fi
+
+if ! grep -Fxq -- 'MVN ?= mvn' "$MAKEFILE"; then
+  printf '%s\n' "Makefile must preserve the Maven command override." >&2
+  exit 1
+fi
 
 for rate_limit_contract in \
   'private static final int MAX_LIVE_DIAL_ATTEMPTS = 5;' \

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -82,7 +82,12 @@ public class DocsPlansTest {
                 "make check must run the scripted baseline guard from the repository root",
                 makefile.contains("\"$(ROOT)/scripts/check-baseline.sh\"")
         );
-        assertTrue(makefile.contains("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"));
+        assertTrue(
+                "ROOT must resist command-line reassignment",
+                makefile.contains("override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))")
+        );
+        assertFalse("ROOT must not depend on the caller's directory", makefile.contains("ROOT := $(CURDIR)"));
+        assertTrue("the Maven executable must remain configurable", makefile.contains("MVN ?= mvn"));
         assertTrue(makefile.contains("cd \"$(ROOT)\" && $(MVN)"));
     }
 


### PR DESCRIPTION
## Summary

Make verification can no longer be redirected away from the reviewed checkout by supplying a command-line `ROOT` value. The repository root is now a protected Makefile-derived invariant, while the intentional Maven executable override remains available.

Static shell and JUnit contracts reject weaker root definitions. The completed maintenance plan records the external-directory, hostile-root, and mutation evidence.

## Baseline

The Make verification entry point previously accepted a caller-controlled `ROOT`, which could redirect repository-owned checks away from the reviewed checkout. The Maven executable override is intentional and remains supported.

## Improvements

- Protect the repository root as a Makefile-derived invariant.
- Preserve the supported Maven executable override.
- Add static shell and JUnit contracts that reject weaker root declarations.
- Record external-directory, hostile-root, and mutation evidence in the completed maintenance plan.

## Validation

- `make check` (42 tests)
- external-directory `make -C <checkout> check`
- hostile `make -C <checkout> ROOT=<empty-directory> check`
- eight hostile mutations
- exact diff, artifact, shell syntax, whitespace, and changed-line secret audits
- exact-head hosted verification for Java 8, 11, 17, and 21 plus the Snyk security status

## Risk

Callers that previously redirected repository checks with `ROOT` must now use the checked-out project, which is the intended verification boundary. The intentional Maven executable override remains available, and no application behavior is changed.

## Follow-Ups

Keep future Makefile changes covered by the hostile-root and mutation contracts. No additional operational monitoring is required because this change affects repository verification tooling rather than a deployed runtime.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
