### PR TITLE
build: harden make verification authority

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,4 +32,4 @@ jobs:
           java-version: ${{ matrix.java-version }}
           cache: maven
       - name: Run repository verification
-        run: make check
+        run: ./scripts/run-make.sh check

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   configuration while preserving literal multiword Maven overrides.
 - Added a fixed-target, physical-root Make wrapper for hosted and trusted local
   verification that clears inherited GNU Make control variables before parse.
+- Replaced permissive workflow command scanning with an exact-byte SHA-256
+  contract and adversarial mutation coverage.
 
 ## 2026-06-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 - Hardened `make check` against Make-syntax Maven expansion, caller shell and
   Makefile identity replacement, execution-skipping flags, and startup-file
   configuration while preserving literal multiword Maven overrides.
+- Added a fixed-target, physical-root Make wrapper for hosted and trusted local
+  verification that clears inherited GNU Make control variables before parse.
 
 ## 2026-06-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+- Hardened `make check` against Make-syntax Maven expansion, caller shell and
+  Makefile identity replacement, execution-skipping flags, and startup-file
+  configuration while preserving literal multiword Maven overrides.
+
 ## 2026-06-19
 
 - Moved live-call rate limiting after form parsing, authorization, and provider

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,75 @@
-.PHONY: build check lint test verify
+.DEFAULT_GOAL := check
+.PHONY: __repository-make-authority build check lint root-test test verify
 
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+PUBLIC_TARGETS := build check lint root-test test verify
+
 MVN ?= mvn
+override MVN := $(value MVN)
+export MVN
+override REPOSITORY_MAKE_DOLLAR := $$
+override REPOSITORY_MAKE_OPEN := (
+ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR)$(REPOSITORY_MAKE_OPEN),$(value MVN)),)
+$(error MVN must be literal command text, not Make syntax)
+endif
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+
+ifneq ($(filter command line,$(origin MAKEFLAGS)),)
+$(error MAKEFLAGS must not be overridden for repository verification)
+endif
+override REPOSITORY_MAKE_FIRST_FLAGS := $(firstword $(MAKEFLAGS))
+ifneq ($(filter -%,$(REPOSITORY_MAKE_FIRST_FLAGS)),)
+override REPOSITORY_MAKE_FIRST_FLAGS :=
+endif
+override REPOSITORY_MAKE_SHORT_FLAGS := $(REPOSITORY_MAKE_FIRST_FLAGS) $(filter-out --%,$(filter -%,$(MAKEFLAGS)))
+ifneq ($(findstring n,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring t,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring q,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring i,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(filter --just-print --dry-run --recon --touch --question --ignore-errors,$(MAKEFLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override REPOSITORY_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+override REPOSITORY_ROOT := $(abspath $(dir $(REPOSITORY_MAKEFILE)))
+override ROOT := $(REPOSITORY_ROOT)
+export ROOT
+
+$(PUBLIC_TARGETS): override SHELL := /bin/sh
+$(PUBLIC_TARGETS): override .SHELLFLAGS := -c
+$(PUBLIC_TARGETS): override ROOT := $(REPOSITORY_ROOT)
+$(PUBLIC_TARGETS): __repository-make-authority
+
+__repository-make-authority:
+	@:
 
 lint:
-	cd "$(ROOT)" && $(MVN) -q -DskipTests compile
+	cd "$$ROOT" && $$MVN -q -DskipTests compile
 
 test:
-	cd "$(ROOT)" && $(MVN) -q test
+	cd "$$ROOT" && $$MVN -q test
 
 build:
-	cd "$(ROOT)" && $(MVN) -q -DskipTests package
+	cd "$$ROOT" && $$MVN -q -DskipTests package
 
 verify: lint test build
 
-check: verify
-	"$(ROOT)/scripts/check-baseline.sh"
+root-test:
+	/bin/sh "$$ROOT/scripts/test-makefile-authority.sh"
+
+check: root-test verify
+	"$$ROOT/scripts/check-baseline.sh"

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ verify: lint test build
 
 root-test:
 	/bin/sh "$$ROOT/scripts/test-makefile-authority.sh"
+	/bin/sh "$$ROOT/scripts/test-workflow-authority.sh"
 
 check: root-test verify
 	"$$ROOT/scripts/check-baseline.sh"

--- a/README.md
+++ b/README.md
@@ -99,16 +99,21 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 ## Testing and Verification
 
+- `scripts/run-make.sh check`
 - `make check`
 - `scripts/check-baseline.sh`
-- When invoked with the checked-in Makefile alone, verification protects its
-  repository root and shell, preserves literal multiword Maven overrides, and
-  rejects skipped-mode flags, populated `MAKEFILES`, and `MAKEFILE_LIST`
-  replacement. Startup files and later caller `-f` files remain outside the
-  documented GNU Make trust boundary.
+- The canonical wrapper accepts exactly `check` or `lint`, resolves its physical
+  checkout through a bounded symbolic-link chain, clears `MAKEFILES`,
+  `MAKEFLAGS`, `MFLAGS`, `MAKEOVERRIDES`, and `GNUMAKEFLAGS`, and invokes the
+  physical repository Makefile with fixed system tools. Literal `MVN` values,
+  Java environment variables, and executable lookup through `PATH` remain
+  caller-controlled so supported local Maven and JDK setups keep working.
+- Direct `make` invocation remains a caller-authority boundary: GNU Make can
+  execute startup files, earlier or later `-f` files, and `--eval` before or
+  outside repository recipes. Use the canonical wrapper for trusted checks.
 - `mvn test`
-- GitHub Actions runs `make check` for all branch pushes, pull requests, and
-  manual dispatches on Java 8, 11, 17, and 21 with read-only repository
+- GitHub Actions runs `scripts/run-make.sh check` for all branch pushes, pull
+  requests, and manual dispatches on Java 8, 11, 17, and 21 with read-only repository
   permissions, non-persisted checkout credentials, Ubuntu 24.04, and immutable
   action pins. The baseline rejects branch-filtered pushes and additional
   workflow files.
@@ -191,8 +196,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   authentication-first live request boundary.
 - See `docs/plans/2026-06-14-supported-toolchain-versions.md` for the Java,
   Maven, and Twilio SDK support boundary.
-- See `docs/plans/2026-06-21-make-authority-hardening.md` for Maven command,
-  shell, flag, startup-file, and Makefile-identity authority checks.
+- See `docs/plans/2026-06-21-make-authority-hardening.md` for the canonical
+  wrapper, Maven command, shell, flag, startup-file, and Makefile authority.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - GitHub Actions runs `scripts/run-make.sh check` for all branch pushes, pull
   requests, and manual dispatches on Java 8, 11, 17, and 21 with read-only repository
   permissions, non-persisted checkout credentials, Ubuntu 24.04, and immutable
-  action pins. The baseline rejects branch-filtered pushes and additional
-  workflow files.
+  action pins. The baseline requires the complete workflow bytes to match the
+  reviewed canonical SHA-256 and rejects additional workflow files.
 - `mvn -DskipTests package`
 - The baseline script checks required project files, completed docs-plan
   metadata, and local editor metadata hygiene.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 - `make check`
 - `scripts/check-baseline.sh`
+- When invoked with the checked-in Makefile alone, verification protects its
+  repository root and shell, preserves literal multiword Maven overrides, and
+  rejects skipped-mode flags, populated `MAKEFILES`, and `MAKEFILE_LIST`
+  replacement. Startup files and later caller `-f` files remain outside the
+  documented GNU Make trust boundary.
 - `mvn test`
 - GitHub Actions runs `make check` for all branch pushes, pull requests, and
   manual dispatches on Java 8, 11, 17, and 21 with read-only repository
@@ -186,6 +191,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   authentication-first live request boundary.
 - See `docs/plans/2026-06-14-supported-toolchain-versions.md` for the Java,
   Maven, and Twilio SDK support boundary.
+- See `docs/plans/2026-06-21-make-authority-hardening.md` for Maven command,
+  shell, flag, startup-file, and Makefile-identity authority checks.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,14 @@ For web services, APIs, sockets, or scraping workflows, prioritize reports invol
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.
 
+Trusted repository verification starts with `scripts/run-make.sh check`. The
+wrapper resolves its physical checkout, accepts only `check` or `lint`, clears
+GNU Make startup and option variables, and uses fixed system tools before Make
+parses the repository. Direct Make invocation permits caller-controlled
+`MAKEFILES`, earlier or later `-f` files, and `--eval` execution and is not the
+trusted entrypoint. Literal `MVN`, Java environment settings, and `PATH` remain
+caller authority; use a trusted JDK and Maven installation for security claims.
+
 ## Safe Research Guidelines
 
 Good-faith research is welcome when it stays within these boundaries:

--- a/VISION.md
+++ b/VISION.md
@@ -16,7 +16,8 @@ Priority:
 
 - Preserve the built-in Java HTTP server and `/twiml` plus `/dial-phone` flow
 - Keep account credentials and phone numbers in environment variables
-- Maintain `make check` and Maven packaging for a runnable jar
+- Maintain the sanitized `scripts/run-make.sh check` entrypoint, direct
+  `make check` compatibility, and Maven packaging for a runnable jar
 - Keep a scriptable baseline guard for required files and maintenance metadata
 - Keep local IDE metadata out of the portable sample
 - Keep deployment port parsing predictable and safe for local fallback

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -1,0 +1,34 @@
+# Make Authority Hardening
+
+## Status: Completed
+
+## Context
+
+The portable `make check` gate protected its root but still accepted Make-syntax
+Maven values, caller shells, execution-skipping flags, startup files, and
+Makefile identity replacement.
+
+## Requirements
+
+- Preserve literal, multiword Maven command overrides.
+- Reject Make-syntax commands before expansion and keep root/shell authority local.
+- Prove repository and external-directory `make check` behavior.
+- Keep all Twilio credentials unset and make no live provider calls.
+
+## Work Completed
+
+- Bound root, shell, Maven command, flag, startup-file, and Makefile identity authority.
+- Added executable adversarial regression coverage to `make check`.
+- Preserved the documented GNU Make startup and later-`-f` trust boundary.
+
+## Verification
+
+- Sanitized repository and external-directory `make check` passed using public
+  Maven Central with live dialing disabled.
+- No Twilio credentials, provider endpoints, recipients, or live calls were used.
+
+## Scope Boundaries
+
+No Java behavior, dependency version, credential handling, provider request,
+workflow, publishing, or deployment changed. GNU Make startup files can execute
+during parsing, and later caller-supplied `-f` files remain outside authority.

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -27,12 +27,20 @@ could also hide dry-run or ignore-errors state with pre-parse `--eval`.
   executable `MAKEFILES`, and earlier and later `-f` files before proving the
   wrapper excludes those paths.
 - Added executable adversarial regression coverage to `make check`.
+- Replaced permissive hosted-workflow YAML scanning with a closed-world SHA-256
+  contract over the complete reviewed workflow bytes.
+- Added mutations for Unicode-escaped, anchored, tagged, and aliased keys,
+  extra pinned and local actions, a custom shell, an extra step, and an
+  otherwise harmless byte change; every mutation must fail closed.
 - Preserved direct Make compatibility while documenting it as caller authority.
 
 ## Verification
 
 - Repository and external-directory wrapper checks passed without changing the
   Maven, Java, or `PATH` caller boundary.
+- The canonical 844-byte workflow independently hashed to
+  `2e38858f6c84fdcc9f67e5eb05081aacf4ff8e72486e5ec4b338a6eddb273571`
+  with `sha256sum`, `shasum -a 256`, and `openssl dgst -sha256`.
 - No Twilio credentials, provider endpoints, recipients, or live calls were used.
 
 ## Scope Boundaries

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -6,29 +6,39 @@
 
 The portable `make check` gate protected its root but still accepted Make-syntax
 Maven values, caller shells, execution-skipping flags, startup files, and
-Makefile identity replacement.
+Makefile identity replacement. Later review showed direct GNU Make invocation
+could also hide dry-run or ignore-errors state with pre-parse `--eval`.
 
 ## Requirements
 
 - Preserve literal, multiword Maven command overrides.
 - Reject Make-syntax commands before expansion and keep root/shell authority local.
+- Add a fixed-target wrapper that clears all inherited Make control channels
+  before GNU Make starts and resolves the physical repository checkout.
 - Prove repository and external-directory `make check` behavior.
 - Keep all Twilio credentials unset and make no live provider calls.
 
 ## Work Completed
 
 - Bound root, shell, Maven command, flag, startup-file, and Makefile identity authority.
+- Added `scripts/run-make.sh` as the trusted `check|lint` entrypoint and wired
+  hosted verification to it.
+- Reproduced hidden `-n` and `-i` state through `--eval`, `GNUMAKEFLAGS`,
+  executable `MAKEFILES`, and earlier and later `-f` files before proving the
+  wrapper excludes those paths.
 - Added executable adversarial regression coverage to `make check`.
-- Preserved the documented GNU Make startup and later-`-f` trust boundary.
+- Preserved direct Make compatibility while documenting it as caller authority.
 
 ## Verification
 
-- Sanitized repository and external-directory `make check` passed using public
-  Maven Central with live dialing disabled.
+- Repository and external-directory wrapper checks passed without changing the
+  Maven, Java, or `PATH` caller boundary.
 - No Twilio credentials, provider endpoints, recipients, or live calls were used.
 
 ## Scope Boundaries
 
 No Java behavior, dependency version, credential handling, provider request,
-workflow, publishing, or deployment changed. GNU Make startup files can execute
-during parsing, and later caller-supplied `-f` files remain outside authority.
+publishing, or deployment changed. Literal `MVN`, Java environment variables,
+and `PATH` remain caller-controlled. Direct Make can execute startup files,
+earlier or later caller-supplied `-f` files, and `--eval`; the wrapper is the
+trusted boundary.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -43,6 +43,8 @@ for path in \
   "docs/plans/2026-06-14-make-root-override-protection.md" \
   "docs/plans/2026-06-14-supported-toolchain-versions.md" \
   "docs/plans/2026-06-19-live-dial-at-most-once.md" \
+  "docs/plans/2026-06-21-make-authority-hardening.md" \
+  "scripts/test-makefile-authority.sh" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
@@ -108,7 +110,7 @@ for plan_contract in \
   fi
 done
 
-make_root='override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))'
+make_root='override ROOT := $(REPOSITORY_ROOT)'
 if ! grep -Fxq -- "$make_root" "$MAKEFILE"; then
   printf '%s\n' "Makefile ROOT must be protected and derived from the loaded Makefile." >&2
   exit 1
@@ -118,6 +120,18 @@ if ! grep -Fxq -- 'MVN ?= mvn' "$MAKEFILE"; then
   printf '%s\n' "Makefile must preserve the Maven command override." >&2
   exit 1
 fi
+
+for authority_contract in \
+  'override MVN := $(value MVN)' \
+  'override SHELL := /bin/sh' \
+  'MAKEFLAGS must not be overridden for repository verification' \
+  'MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone' \
+  'MAKEFILE_LIST must not be overridden'; do
+  if ! grep -Fq -- "$authority_contract" "$MAKEFILE"; then
+    printf '%s\n' "Makefile is missing authority contract: $authority_contract" >&2
+    exit 1
+  fi
+done
 
 for rate_limit_contract in \
   'private static final int MAX_LIVE_DIAL_ATTEMPTS = 5;' \
@@ -311,19 +325,27 @@ for form_content_type_contract in \
   fi
 done
 
-if ! grep -Fq '"$(ROOT)/scripts/check-baseline.sh"' "$MAKEFILE"; then
+if ! grep -Fq '"$$ROOT/scripts/check-baseline.sh"' "$MAKEFILE"; then
   printf '%s\n' "Makefile must run scripts/check-baseline.sh from make check." >&2
   exit 1
 fi
 
 for make_contract in \
-  'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' \
-  'cd "$(ROOT)" && $(MVN)'; do
+  '.PHONY: __repository-make-authority build check lint root-test test verify' \
+  'ROOT := $(REPOSITORY_ROOT)' \
+  'cd "$$ROOT" && $$MVN' \
+  '/bin/sh "$$ROOT/scripts/test-makefile-authority.sh"' \
+  'check: root-test verify'; do
   if ! grep -Fq -- "$make_contract" "$MAKEFILE"; then
     printf '%s\n' "Makefile is missing root-independent contract: $make_contract" >&2
     exit 1
   fi
 done
+
+if ! grep -Fq 'docs/plans/2026-06-21-make-authority-hardening.md' "$README"; then
+  printf '%s\n' "README must index Make authority hardening evidence." >&2
+  exit 1
+fi
 
 for target in "lint:" "test:" "build:" "verify:" "check:"; do
   if ! grep -Fq "$target" "$MAKEFILE"; then

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -46,6 +46,7 @@ for path in \
   "docs/plans/2026-06-21-make-authority-hardening.md" \
   "scripts/run-make.sh" \
   "scripts/test-makefile-authority.sh" \
+  "scripts/test-workflow-authority.sh" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
@@ -283,30 +284,28 @@ if [ "$workflow_files" != "$WORKFLOW" ]; then
   exit 1
 fi
 
-for workflow_contract in \
-  "permissions:" \
-  "contents: read" \
-  "persist-credentials: false" \
-  "run: ./scripts/run-make.sh check"; do
-  if ! grep -Fq -- "$workflow_contract" "$WORKFLOW"; then
-    printf '%s\n' "Hosted verification is missing security contract: $workflow_contract" >&2
-    exit 1
-  fi
-done
-
-if [ "$(grep -Fc 'run: ./scripts/run-make.sh check' "$WORKFLOW")" -ne 1 ]; then
-  printf '%s\n' "Hosted verification must use exactly one sanitized Make invocation." >&2
+EXPECTED_WORKFLOW_SHA256=2e38858f6c84fdcc9f67e5eb05081aacf4ff8e72486e5ec4b338a6eddb273571
+if command -v sha256sum >/dev/null 2>&1; then
+  workflow_sha256=$(sha256sum "$WORKFLOW" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  workflow_sha256=$(shasum -a 256 "$WORKFLOW" | awk '{print $1}')
+else
+  printf '%s\n' "SHA-256 tool is required to verify the hosted workflow." >&2
   exit 1
 fi
-
-if grep -Eq 'run:[[:space:]]+(make|gmake)[[:space:]]' "$WORKFLOW"; then
-  printf '%s\n' "Hosted verification must not invoke Make directly." >&2
+if [ "$workflow_sha256" != "$EXPECTED_WORKFLOW_SHA256" ]; then
+  printf '%s\n' "Hosted workflow bytes do not match the reviewed canonical contract." >&2
   exit 1
 fi
 
 MAKE_WRAPPER="$ROOT_DIR/scripts/run-make.sh"
 if [ ! -x "$MAKE_WRAPPER" ]; then
   printf '%s\n' "scripts/run-make.sh must be executable." >&2
+  exit 1
+fi
+
+if [ ! -x "$ROOT_DIR/scripts/test-workflow-authority.sh" ]; then
+  printf '%s\n' "scripts/test-workflow-authority.sh must be executable." >&2
   exit 1
 fi
 
@@ -324,31 +323,6 @@ for wrapper_contract in \
   '/usr/bin/make --no-print-directory -f "$ROOT/Makefile" "$target"'; do
   if ! grep -Fq -- "$wrapper_contract" "$MAKE_WRAPPER"; then
     printf '%s\n' "Make wrapper is missing required contract: $wrapper_contract" >&2
-    exit 1
-  fi
-done
-
-if grep -Eq '^[[:space:]]*[[:alnum:]_-]+:[[:space:]]*write([[:space:]]|$)' "$WORKFLOW"; then
-  printf '%s\n' "Hosted verification must not grant write permissions." >&2
-  exit 1
-fi
-
-if grep -Fq "pull_request_target:" "$WORKFLOW"; then
-  printf '%s\n' "Hosted verification must not run untrusted changes with pull_request_target." >&2
-  exit 1
-fi
-
-if grep -Fq "branches:" "$WORKFLOW"; then
-  printf '%s\n' "Hosted push verification must cover all branches." >&2
-  exit 1
-fi
-
-for event_contract in \
-  "  pull_request:" \
-  "  push:" \
-  "  workflow_dispatch:"; do
-  if ! grep -Fxq -- "$event_contract" "$WORKFLOW"; then
-    printf '%s\n' "Hosted verification is missing canonical event: $event_contract" >&2
     exit 1
   fi
 done
@@ -389,6 +363,7 @@ for make_contract in \
   'ROOT := $(REPOSITORY_ROOT)' \
   'cd "$$ROOT" && $$MVN' \
   '/bin/sh "$$ROOT/scripts/test-makefile-authority.sh"' \
+  '/bin/sh "$$ROOT/scripts/test-workflow-authority.sh"' \
   'check: root-test verify'; do
   if ! grep -Fq -- "$make_contract" "$MAKEFILE"; then
     printf '%s\n' "Makefile is missing root-independent contract: $make_contract" >&2

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 README="$ROOT_DIR/README.md"
 MAKEFILE="$ROOT_DIR/Makefile"
 GITIGNORE="$ROOT_DIR/.gitignore"
@@ -44,6 +44,7 @@ for path in \
   "docs/plans/2026-06-14-supported-toolchain-versions.md" \
   "docs/plans/2026-06-19-live-dial-at-most-once.md" \
   "docs/plans/2026-06-21-make-authority-hardening.md" \
+  "scripts/run-make.sh" \
   "scripts/test-makefile-authority.sh" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
@@ -129,6 +130,24 @@ for authority_contract in \
   'MAKEFILE_LIST must not be overridden'; do
   if ! grep -Fq -- "$authority_contract" "$MAKEFILE"; then
     printf '%s\n' "Makefile is missing authority contract: $authority_contract" >&2
+    exit 1
+  fi
+done
+
+for documented_wrapper_contract in \
+  'scripts/run-make.sh check' \
+  '`MAKEFILES`' \
+  '`MAKEFLAGS`' \
+  '`MFLAGS`' \
+  '`MAKEOVERRIDES`' \
+  '`GNUMAKEFLAGS`' \
+  'earlier or later `-f` files' \
+  'Literal `MVN` values' \
+  'Java environment variables' \
+  '`PATH` remain'; do
+  if ! grep -Fq -- "$documented_wrapper_contract" "$README" && \
+     ! grep -Fq -- "$documented_wrapper_contract" "$ROOT_DIR/SECURITY.md"; then
+    printf '%s\n' "Make wrapper boundary is not documented: $documented_wrapper_contract" >&2
     exit 1
   fi
 done
@@ -267,9 +286,44 @@ fi
 for workflow_contract in \
   "permissions:" \
   "contents: read" \
-  "persist-credentials: false"; do
+  "persist-credentials: false" \
+  "run: ./scripts/run-make.sh check"; do
   if ! grep -Fq -- "$workflow_contract" "$WORKFLOW"; then
     printf '%s\n' "Hosted verification is missing security contract: $workflow_contract" >&2
+    exit 1
+  fi
+done
+
+if [ "$(grep -Fc 'run: ./scripts/run-make.sh check' "$WORKFLOW")" -ne 1 ]; then
+  printf '%s\n' "Hosted verification must use exactly one sanitized Make invocation." >&2
+  exit 1
+fi
+
+if grep -Eq 'run:[[:space:]]+(make|gmake)[[:space:]]' "$WORKFLOW"; then
+  printf '%s\n' "Hosted verification must not invoke Make directly." >&2
+  exit 1
+fi
+
+MAKE_WRAPPER="$ROOT_DIR/scripts/run-make.sh"
+if [ ! -x "$MAKE_WRAPPER" ]; then
+  printf '%s\n' "scripts/run-make.sh must be executable." >&2
+  exit 1
+fi
+
+for wrapper_contract in \
+  'case $0 in' \
+  'if [ "$link_count" -gt 40 ]' \
+  '/usr/bin/readlink -n "$script_path"' \
+  'usage: scripts/run-make.sh check|lint' \
+  'check|lint)' \
+  '-u MAKEFILES' \
+  '-u MAKEFLAGS' \
+  '-u MFLAGS' \
+  '-u MAKEOVERRIDES' \
+  '-u GNUMAKEFLAGS' \
+  '/usr/bin/make --no-print-directory -f "$ROOT/Makefile" "$target"'; do
+  if ! grep -Fq -- "$wrapper_contract" "$MAKE_WRAPPER"; then
+    printf '%s\n' "Make wrapper is missing required contract: $wrapper_contract" >&2
     exit 1
   fi
 done

--- a/scripts/run-make.sh
+++ b/scripts/run-make.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+case $0 in
+  /*) script_path=$0 ;;
+  *) script_path=$(/bin/pwd -P)/$0 ;;
+esac
+
+link_count=0
+while [ -L "$script_path" ]; do
+  link_count=$((link_count + 1))
+  if [ "$link_count" -gt 40 ]; then
+    printf '%s\n' 'repository verification entrypoint has too many symbolic links' >&2
+    exit 66
+  fi
+
+  if ! link_target_with_sentinel=$(/usr/bin/readlink -n "$script_path" && printf x); then
+    printf '%s\n' 'repository verification entrypoint could not read symbolic link' >&2
+    exit 66
+  fi
+  link_target=${link_target_with_sentinel%x}
+  case $link_target in
+    /*) script_path=$link_target ;;
+    *) script_path=$(/usr/bin/dirname "$script_path")/$link_target ;;
+  esac
+done
+
+if [ ! -f "$script_path" ]; then
+  printf '%s\n' 'repository verification entrypoint did not resolve to a regular file' >&2
+  exit 66
+fi
+
+script_dir=$(CDPATH='' cd -P "$(/usr/bin/dirname "$script_path")" && /bin/pwd -P)
+ROOT=$(CDPATH='' cd -P "$script_dir/.." && /bin/pwd -P)
+
+if [ "$#" -ne 1 ]; then
+  printf '%s\n' 'usage: scripts/run-make.sh check|lint' >&2
+  exit 64
+fi
+
+case $1 in
+  check|lint)
+    target=$1
+    ;;
+  *)
+    printf 'unsupported repository verification target: %s\n' "$1" >&2
+    exit 64
+    ;;
+esac
+
+exec /usr/bin/env \
+  -u MAKEFILES \
+  -u MAKEFLAGS \
+  -u MFLAGS \
+  -u MAKEOVERRIDES \
+  -u GNUMAKEFLAGS \
+  /usr/bin/make --no-print-directory -f "$ROOT/Makefile" "$target"

--- a/scripts/test-makefile-authority.sh
+++ b/scripts/test-makefile-authority.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+MAKEFILE=$ROOT_DIR/Makefile
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/twilio-java-make-authority-XXXXXX")
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+CONTROL_DIR=$TEMP_ROOT/control
+ATTACKER_ROOT=$TEMP_ROOT/attacker
+MARKER=$TEMP_ROOT/make-syntax-expanded
+TOOL_LOG=$TEMP_ROOT/tool.log
+mkdir -p "$CONTROL_DIR" "$ATTACKER_ROOT"
+
+run_make() { (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory -f "$MAKEFILE" "$@"); }
+
+fake_tool=$TEMP_ROOT/fake-maven
+cat >"$fake_tool" <<EOF
+#!/bin/sh
+printf 'cwd=%s args=%s\n' "\$PWD" "\$*" >>"$TOOL_LOG"
+exit 0
+EOF
+chmod +x "$fake_tool"
+
+: >"$TOOL_LOG"
+run_make lint ROOT="$ATTACKER_ROOT" MVN="$fake_tool --settings fixture.xml" >/dev/null
+grep -F "cwd=$ROOT_DIR" "$TOOL_LOG" >/dev/null
+grep -F 'args=--settings fixture.xml -q -DskipTests compile' "$TOOL_LOG" >/dev/null
+if grep -F "$ATTACKER_ROOT" "$TOOL_LOG" >/dev/null; then echo "ROOT redirected verification" >&2; exit 1; fi
+
+: >"$TOOL_LOG"
+run_make lint SHELL=/bin/false MVN="$fake_tool" >/dev/null
+grep -F "cwd=$ROOT_DIR" "$TOOL_LOG" >/dev/null
+
+rm -f "$MARKER"
+set +e
+run_make lint "MVN=\$(shell /usr/bin/touch '$MARKER')mvn" >"$TEMP_ROOT/mvn.out" 2>"$TEMP_ROOT/mvn.err"
+status=$?
+set -e
+if [ "$status" -eq 0 ] || [ -e "$MARKER" ]; then echo "Make-syntax MVN was not rejected safely" >&2; exit 1; fi
+grep -F "MVN must be literal command text" "$TEMP_ROOT/mvn.err" >/dev/null
+
+set +e
+run_make lint MAKEFLAGS=--just-print >"$TEMP_ROOT/flags.out" 2>"$TEMP_ROOT/flags.err"; status=$?
+set -e
+if [ "$status" -eq 0 ]; then echo "MAKEFLAGS was not rejected" >&2; exit 1; fi
+grep -F "MAKEFLAGS must not be overridden" "$TEMP_ROOT/flags.err" >/dev/null
+
+startup=$TEMP_ROOT/startup.mk
+printf '%s\n' 'STARTUP_FILE_LOADED := yes' >"$startup"
+set +e
+(cd "$CONTROL_DIR" && MAKEFILES="$startup" /usr/bin/make --no-print-directory -f "$MAKEFILE" lint) >"$TEMP_ROOT/startup.out" 2>"$TEMP_ROOT/startup.err"; status=$?
+set -e
+if [ "$status" -eq 0 ]; then echo "MAKEFILES was not rejected" >&2; exit 1; fi
+grep -F "MAKEFILES must be empty" "$TEMP_ROOT/startup.err" >/dev/null
+
+set +e
+run_make lint MVN="$fake_tool" MAKEFILE_LIST="$TEMP_ROOT/attacker.mk" >"$TEMP_ROOT/list.out" 2>"$TEMP_ROOT/list.err"; status=$?
+set -e
+if [ "$status" -eq 0 ]; then echo "MAKEFILE_LIST was not rejected" >&2; exit 1; fi
+grep -F "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/list.err" >/dev/null
+
+printf '%s\n' "Make authority tests passed: root, shell, Maven command, MAKEFLAGS, MAKEFILES, and MAKEFILE_LIST"

--- a/scripts/test-makefile-authority.sh
+++ b/scripts/test-makefile-authority.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eu
 
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd -P)
 MAKEFILE=$ROOT_DIR/Makefile
+WRAPPER=$ROOT_DIR/scripts/run-make.sh
 TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/twilio-java-make-authority-XXXXXX")
 trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
 CONTROL_DIR=$TEMP_ROOT/control
@@ -59,4 +60,142 @@ set -e
 if [ "$status" -eq 0 ]; then echo "MAKEFILE_LIST was not rejected" >&2; exit 1; fi
 grep -F "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/list.err" >/dev/null
 
-printf '%s\n' "Make authority tests passed: root, shell, Maven command, MAKEFLAGS, MAKEFILES, and MAKEFILE_LIST"
+GNU_MAKE=${GNU_MAKE:-}
+if [ -z "$GNU_MAKE" ] && command -v gmake >/dev/null 2>&1; then
+  GNU_MAKE=$(command -v gmake)
+fi
+
+if [ -n "$GNU_MAKE" ]; then
+  : >"$TOOL_LOG"
+  "$GNU_MAKE" --no-print-directory -n \
+    --eval='override MAKEFLAGS :=' \
+    -f "$MAKEFILE" lint MVN="$fake_tool" \
+    >"$TEMP_ROOT/dry-run.out" 2>"$TEMP_ROOT/dry-run.err"
+  if [ -s "$TOOL_LOG" ]; then
+    echo "raw GNU Make dry-run bypass did not reproduce" >&2
+    exit 1
+  fi
+
+  failing_tool=$TEMP_ROOT/failing-maven
+  cat >"$failing_tool" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+  chmod +x "$failing_tool"
+  "$GNU_MAKE" --no-print-directory -i \
+    --eval='override MAKEFLAGS :=' \
+    -f "$MAKEFILE" lint MVN="$failing_tool" \
+    >"$TEMP_ROOT/ignore-errors.out" 2>"$TEMP_ROOT/ignore-errors.err"
+
+  : >"$TOOL_LOG"
+  GNUMAKEFLAGS=-n "$GNU_MAKE" --no-print-directory \
+    --eval='override MAKEFLAGS :=' \
+    -f "$MAKEFILE" lint MVN="$fake_tool" \
+    >"$TEMP_ROOT/gnumakeflags.out" 2>"$TEMP_ROOT/gnumakeflags.err"
+  if [ -s "$TOOL_LOG" ]; then
+    echo "raw GNUMAKEFLAGS bypass did not reproduce" >&2
+    exit 1
+  fi
+fi
+
+startup_marker=$TEMP_ROOT/startup-executed
+cat >"$startup" <<EOF
+\$(shell /usr/bin/touch '$startup_marker')
+override MAKEFILES :=
+EOF
+MAKEFILES="$startup" /usr/bin/make --no-print-directory \
+  -f "$MAKEFILE" lint MVN="$fake_tool" \
+  >"$TEMP_ROOT/startup-exec.out" 2>"$TEMP_ROOT/startup-exec.err"
+if [ ! -e "$startup_marker" ]; then
+  echo "raw executable MAKEFILES bypass did not reproduce" >&2
+  exit 1
+fi
+
+earlier=$TEMP_ROOT/earlier.mk
+earlier_marker=$TEMP_ROOT/earlier-executed
+cat >"$earlier" <<EOF
+\$(shell /usr/bin/touch '$earlier_marker')
+EOF
+/usr/bin/make --no-print-directory -f "$earlier" -f "$MAKEFILE" \
+  lint MVN="$fake_tool" \
+  >"$TEMP_ROOT/earlier.out" 2>"$TEMP_ROOT/earlier.err"
+if [ ! -e "$earlier_marker" ]; then
+  echo "raw earlier -f bypass did not reproduce" >&2
+  exit 1
+fi
+
+later=$TEMP_ROOT/later.mk
+later_marker=$TEMP_ROOT/later-executed
+cat >"$later" <<EOF
+\$(shell /usr/bin/touch '$later_marker')
+EOF
+/usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$later" \
+  lint MVN="$fake_tool" \
+  >"$TEMP_ROOT/later.out" 2>"$TEMP_ROOT/later.err"
+if [ ! -e "$later_marker" ]; then
+  echo "raw later -f bypass did not reproduce" >&2
+  exit 1
+fi
+
+if [ ! -x "$WRAPPER" ]; then
+  echo "sanitized Make wrapper is missing" >&2
+  exit 1
+fi
+
+for rejected in '' 'test' '-n' '--eval=all:' 'ROOT=/tmp' 'lint extra'; do
+  set +e
+  if [ -z "$rejected" ]; then
+    "$WRAPPER" >"$TEMP_ROOT/wrapper-reject.out" 2>"$TEMP_ROOT/wrapper-reject.err"
+  elif [ "$rejected" = 'lint extra' ]; then
+    "$WRAPPER" lint extra >"$TEMP_ROOT/wrapper-reject.out" 2>"$TEMP_ROOT/wrapper-reject.err"
+  else
+    "$WRAPPER" "$rejected" >"$TEMP_ROOT/wrapper-reject.out" 2>"$TEMP_ROOT/wrapper-reject.err"
+  fi
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "wrapper accepted unsupported arguments: $rejected" >&2
+    exit 1
+  fi
+done
+
+: >"$TOOL_LOG"
+MVN="$fake_tool --settings fixture.xml" "$WRAPPER" lint >/dev/null
+grep -F "cwd=$ROOT_DIR" "$TOOL_LOG" >/dev/null
+grep -F 'args=--settings fixture.xml -q -DskipTests compile' "$TOOL_LOG" >/dev/null
+
+wrapper_marker=$TEMP_ROOT/wrapper-startup-executed
+cat >"$startup" <<EOF
+\$(shell /usr/bin/touch '$wrapper_marker')
+EOF
+: >"$TOOL_LOG"
+MAKEFILES="$startup" \
+MAKEFLAGS='--just-print' \
+MFLAGS='-i' \
+MAKEOVERRIDES='ROOT=/tmp' \
+GNUMAKEFLAGS="--eval=\$(shell /usr/bin/touch '$wrapper_marker')" \
+MVN="$fake_tool" \
+  "$WRAPPER" lint >/dev/null
+if [ -e "$wrapper_marker" ]; then
+  echo "wrapper allowed inherited Make startup authority" >&2
+  exit 1
+fi
+
+mkdir -p "$ATTACKER_ROOT/scripts"
+cat >"$ATTACKER_ROOT/Makefile" <<EOF
+lint:
+	@/usr/bin/touch '$TEMP_ROOT/attacker-makefile-executed'
+EOF
+ln -s "$WRAPPER" "$ATTACKER_ROOT/physical
+"
+ln -s "../physical
+" "$ATTACKER_ROOT/scripts/run-make.sh"
+: >"$TOOL_LOG"
+MVN="$fake_tool" "$ATTACKER_ROOT/scripts/run-make.sh" lint >/dev/null
+if [ -e "$TEMP_ROOT/attacker-makefile-executed" ]; then
+  echo "wrapper symlink redirected repository root" >&2
+  exit 1
+fi
+grep -F "cwd=$ROOT_DIR" "$TOOL_LOG" >/dev/null
+
+printf '%s\n' "Make authority tests passed: raw bypasses reproduced and sanitized wrapper excluded them"

--- a/scripts/test-workflow-authority.sh
+++ b/scripts/test-workflow-authority.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd -P)
+WORKFLOW=$ROOT_DIR/.github/workflows/check.yml
+BASELINE=$ROOT_DIR/scripts/check-baseline.sh
+EXPECTED_SHA256=2e38858f6c84fdcc9f67e5eb05081aacf4ff8e72486e5ec4b338a6eddb273571
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/twilio-java-workflow-authority-XXXXXX")
+ORIGINAL=$TEMP_ROOT/check.yml
+
+cp "$WORKFLOW" "$ORIGINAL"
+restore_workflow() {
+  cp "$ORIGINAL" "$WORKFLOW"
+}
+trap 'restore_workflow; rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+
+actual_sha256=$(sha256sum "$ORIGINAL" | awk '{print $1}')
+if [ "$actual_sha256" != "$EXPECTED_SHA256" ]; then
+  printf '%s\n' "Canonical workflow fixture hash mismatch: $actual_sha256" >&2
+  exit 1
+fi
+
+assert_rejected() {
+  mutation=$1
+  restore_workflow
+  case $mutation in
+    unicode-escaped-run-key)
+      awk '/run: \.\/scripts\/run-make\.sh check/ { print "        \"r\\u0075n\": echo bypass" } { print }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    anchored-key)
+      awk '/run: \.\/scripts\/run-make\.sh check/ { print "        &command run: echo anchored" } { print }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    tagged-key)
+      awk '/run: \.\/scripts\/run-make\.sh check/ { print "        !<tag:yaml.org,2002:str> run: echo tagged" } { print }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    aliased-key)
+      awk '/run: \.\/scripts\/run-make\.sh check/ { print "        *command: echo aliased" } { print }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    extra-pinned-action)
+      awk '/- name: Run repository verification/ { print "      - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a" } { print }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    extra-local-action)
+      awk '/- name: Run repository verification/ { print "      - uses: ./.github/actions/local-check" } { print }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    custom-shell)
+      awk '{ print } /run: \.\/scripts\/run-make\.sh check/ { print "        shell: python" }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    extra-step)
+      awk '/- name: Run repository verification/ { print "      - name: Unreviewed extra step" } { print }' "$ORIGINAL" >"$WORKFLOW"
+      ;;
+    byte-change)
+      cat "$ORIGINAL" >"$WORKFLOW"
+      printf '%s\n' '# byte change' >>"$WORKFLOW"
+      ;;
+    *)
+      printf '%s\n' "Unknown workflow mutation: $mutation" >&2
+      exit 1
+      ;;
+  esac
+
+  mutated_sha256=$(sha256sum "$WORKFLOW" | awk '{print $1}')
+  if [ "$mutated_sha256" = "$EXPECTED_SHA256" ]; then
+    printf '%s\n' "Workflow mutation did not change canonical bytes: $mutation" >&2
+    exit 1
+  fi
+
+  if "$BASELINE" >"$TEMP_ROOT/$mutation.out" 2>"$TEMP_ROOT/$mutation.err"; then
+    printf '%s\n' "Workflow mutation was accepted: $mutation" >&2
+    exit 1
+  fi
+  if ! grep -Fq 'Hosted workflow bytes do not match the reviewed canonical contract.' \
+    "$TEMP_ROOT/$mutation.err"; then
+    printf '%s\n' "Workflow mutation failed outside the exact-byte contract: $mutation" >&2
+    exit 1
+  fi
+}
+
+for mutation in \
+  unicode-escaped-run-key \
+  anchored-key \
+  tagged-key \
+  aliased-key \
+  extra-pinned-action \
+  extra-local-action \
+  custom-shell \
+  extra-step \
+  byte-change; do
+  assert_rejected "$mutation"
+done
+
+restore_workflow
+"$BASELINE"
+printf '%s\n' 'Workflow authority tests passed: 9 byte-distinct mutations rejected by the exact hash contract'

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -150,12 +150,7 @@ public class DocsPlansTest {
         assertTrue(workflow.contains("workflow_dispatch:"));
         assertTrue(workflow.contains("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"));
         assertTrue(workflow.contains("actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.1.0"));
-        List<String> runCommands = new ArrayList<>();
-        for (String line : workflow.split("\\r?\\n")) {
-            if (line.trim().startsWith("run:")) {
-                runCommands.add(line.trim());
-            }
-        }
+        List<String> runCommands = workflowRunCommands(workflow);
         assertEquals(
                 "workflow must use only the sanitized repository verification command",
                 Collections.singletonList("run: ./scripts/run-make.sh check"),
@@ -167,6 +162,27 @@ public class DocsPlansTest {
                 "(?s).*\\n\\s*[A-Za-z0-9_-]+:\\s*write(?:\\s|$).*"
         ));
         assertFalse("workflow must not use pull_request_target", workflow.contains("pull_request_target:"));
+    }
+
+    @Test
+    public void hostedCommandScannerRecognizesYamlEquivalentRunKeys() {
+        String[][] mutations = {
+                {"steps:\n  - \"run\": echo double-quoted-key\n", "run: echo double-quoted-key"},
+                {"steps:\n  - run : echo spaced-colon\n", "run: echo spaced-colon"},
+                {"steps:\n  - 'run': echo single-quoted-key\n", "run: echo single-quoted-key"},
+                {"steps:\n  - run: echo sequence-mapping\n", "run: echo sequence-mapping"},
+                {"steps:\n  - {name: Extra, run: echo flow-mapping}\n", "run: echo flow-mapping"},
+                {"steps:\n  - {name: Extra, 'run' : 'echo quoted-flow'}\n", "run: echo quoted-flow"},
+                {"steps:\n  - ? run\n    : echo explicit-key\n", "run: echo explicit-key"}
+        };
+
+        for (String[] mutation : mutations) {
+            assertEquals(
+                    mutation[0],
+                    Collections.singletonList(mutation[1]),
+                    workflowRunCommands(mutation[0])
+            );
+        }
     }
 
     @Test
@@ -201,5 +217,213 @@ public class DocsPlansTest {
                 Files.readAllBytes(REPO_ROOT.resolve(relativePath)),
                 StandardCharsets.UTF_8
         );
+    }
+
+    private static List<String> workflowRunCommands(String workflow) {
+        List<String> runCommands = new ArrayList<>();
+        boolean explicitRunKey = false;
+        for (String rawLine : workflow.split("\\r?\\n")) {
+            String line = stripYamlComment(rawLine);
+            int contentStart = skipSpaces(line, 0);
+            if (contentStart == line.length()) {
+                continue;
+            }
+
+            if (explicitRunKey) {
+                if (line.charAt(contentStart) == ':') {
+                    runCommands.add("run: " + normalizeYamlScalar(line.substring(contentStart + 1)));
+                    explicitRunKey = false;
+                    continue;
+                }
+                explicitRunKey = false;
+            }
+
+            RunMapping blockMapping = parseRunMapping(line, contentStart, true);
+            if (blockMapping != null) {
+                if (blockMapping.explicit) {
+                    explicitRunKey = true;
+                } else {
+                    runCommands.add("run: " + blockMapping.value);
+                }
+            }
+
+            char quote = 0;
+            for (int index = contentStart; index < line.length(); index++) {
+                char current = line.charAt(index);
+                if (quote != 0) {
+                    if (current == quote) {
+                        if (quote == '\'' && index + 1 < line.length()
+                                && line.charAt(index + 1) == '\'') {
+                            index++;
+                        } else if (quote == '"' && index > 0 && line.charAt(index - 1) == '\\') {
+                            continue;
+                        } else {
+                            quote = 0;
+                        }
+                    }
+                    continue;
+                }
+                if (current == '\'' || current == '"') {
+                    quote = current;
+                } else if (current == '{' || current == ',') {
+                    RunMapping flowMapping = parseRunMapping(line, index + 1, false);
+                    if (flowMapping != null) {
+                        runCommands.add("run: " + flowMapping.value);
+                    }
+                }
+            }
+        }
+        return runCommands;
+    }
+
+    private static RunMapping parseRunMapping(String line, int start, boolean allowSequenceMarker) {
+        int index = skipSpaces(line, start);
+        if (allowSequenceMarker && index < line.length() && line.charAt(index) == '-') {
+            index = skipSpaces(line, index + 1);
+        }
+
+        boolean explicit = false;
+        if (allowSequenceMarker && index < line.length() && line.charAt(index) == '?') {
+            explicit = true;
+            index = skipSpaces(line, index + 1);
+        }
+
+        ParsedScalar key = parseYamlScalar(line, index, true);
+        if (key == null || !"run".equals(key.value)) {
+            return null;
+        }
+
+        index = skipSpaces(line, key.end);
+        if (explicit && index == line.length()) {
+            return new RunMapping(true, "");
+        }
+        if (index >= line.length() || line.charAt(index) != ':') {
+            return null;
+        }
+
+        String value = line.substring(index + 1);
+        int flowEnd = findFlowValueEnd(value);
+        return new RunMapping(false, normalizeYamlScalar(value.substring(0, flowEnd)));
+    }
+
+    private static ParsedScalar parseYamlScalar(String line, int start, boolean key) {
+        if (start >= line.length()) {
+            return null;
+        }
+        char first = line.charAt(start);
+        if (first == '\'' || first == '"') {
+            StringBuilder value = new StringBuilder();
+            for (int index = start + 1; index < line.length(); index++) {
+                char current = line.charAt(index);
+                if (current == first) {
+                    if (first == '\'' && index + 1 < line.length()
+                            && line.charAt(index + 1) == '\'') {
+                        value.append('\'');
+                        index++;
+                        continue;
+                    }
+                    return new ParsedScalar(value.toString(), index + 1);
+                }
+                if (first == '"' && current == '\\' && index + 1 < line.length()) {
+                    value.append(line.charAt(++index));
+                } else {
+                    value.append(current);
+                }
+            }
+            return null;
+        }
+
+        int end = start;
+        while (end < line.length()) {
+            char current = line.charAt(end);
+            if (current == ':' || Character.isWhitespace(current)
+                    || current == ',' || current == '}' || current == ']') {
+                break;
+            }
+            end++;
+        }
+        if (end == start || (!key && end != line.length())) {
+            return null;
+        }
+        return new ParsedScalar(line.substring(start, end), end);
+    }
+
+    private static String normalizeYamlScalar(String scalar) {
+        String trimmed = scalar.trim();
+        ParsedScalar parsed = parseYamlScalar(trimmed, 0, false);
+        return parsed == null ? trimmed : parsed.value;
+    }
+
+    private static int findFlowValueEnd(String value) {
+        char quote = 0;
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (quote != 0) {
+                if (current == quote) {
+                    if (quote == '\'' && index + 1 < value.length()
+                            && value.charAt(index + 1) == '\'') {
+                        index++;
+                    } else if (quote != '"' || index == 0 || value.charAt(index - 1) != '\\') {
+                        quote = 0;
+                    }
+                }
+            } else if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (current == ',' || current == '}') {
+                return index;
+            }
+        }
+        return value.length();
+    }
+
+    private static String stripYamlComment(String line) {
+        char quote = 0;
+        for (int index = 0; index < line.length(); index++) {
+            char current = line.charAt(index);
+            if (quote != 0) {
+                if (current == quote) {
+                    if (quote == '\'' && index + 1 < line.length()
+                            && line.charAt(index + 1) == '\'') {
+                        index++;
+                    } else if (quote != '"' || index == 0 || line.charAt(index - 1) != '\\') {
+                        quote = 0;
+                    }
+                }
+            } else if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (current == '#'
+                    && (index == 0 || Character.isWhitespace(line.charAt(index - 1)))) {
+                return line.substring(0, index);
+            }
+        }
+        return line;
+    }
+
+    private static int skipSpaces(String value, int start) {
+        int index = start;
+        while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static final class ParsedScalar {
+        private final String value;
+        private final int end;
+
+        private ParsedScalar(String value, int end) {
+            this.value = value;
+            this.end = end;
+        }
+    }
+
+    private static final class RunMapping {
+        private final boolean explicit;
+        private final String value;
+
+        private RunMapping(boolean explicit, String value) {
+            this.explicit = explicit;
+            this.value = value;
+        }
     }
 }

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -8,8 +8,9 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
@@ -150,12 +151,7 @@ public class DocsPlansTest {
         assertTrue(workflow.contains("workflow_dispatch:"));
         assertTrue(workflow.contains("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"));
         assertTrue(workflow.contains("actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.1.0"));
-        List<String> runCommands = workflowRunCommands(workflow);
-        assertEquals(
-                "workflow must use only the sanitized repository verification command",
-                Collections.singletonList("run: ./scripts/run-make.sh check"),
-                runCommands
-        );
+        assertTrue(workflow.contains("run: ./scripts/run-make.sh check"));
         assertFalse("workflow must not use floating runners", workflow.contains("ubuntu-latest"));
         assertFalse("actions must use immutable commits", workflow.contains("@v"));
         assertFalse("workflow must not grant write permissions", workflow.matches(
@@ -165,24 +161,13 @@ public class DocsPlansTest {
     }
 
     @Test
-    public void hostedCommandScannerRecognizesYamlEquivalentRunKeys() {
-        String[][] mutations = {
-                {"steps:\n  - \"run\": echo double-quoted-key\n", "run: echo double-quoted-key"},
-                {"steps:\n  - run : echo spaced-colon\n", "run: echo spaced-colon"},
-                {"steps:\n  - 'run': echo single-quoted-key\n", "run: echo single-quoted-key"},
-                {"steps:\n  - run: echo sequence-mapping\n", "run: echo sequence-mapping"},
-                {"steps:\n  - {name: Extra, run: echo flow-mapping}\n", "run: echo flow-mapping"},
-                {"steps:\n  - {name: Extra, 'run' : 'echo quoted-flow'}\n", "run: echo quoted-flow"},
-                {"steps:\n  - ? run\n    : echo explicit-key\n", "run: echo explicit-key"}
-        };
+    public void hostedWorkflowMatchesReviewedCanonicalBytes() throws Exception {
+        byte[] workflow = Files.readAllBytes(REPO_ROOT.resolve(".github/workflows/check.yml"));
 
-        for (String[] mutation : mutations) {
-            assertEquals(
-                    mutation[0],
-                    Collections.singletonList(mutation[1]),
-                    workflowRunCommands(mutation[0])
-            );
-        }
+        assertEquals(
+                "2e38858f6c84fdcc9f67e5eb05081aacf4ff8e72486e5ec4b338a6eddb273571",
+                sha256Hex(workflow)
+        );
     }
 
     @Test
@@ -219,211 +204,12 @@ public class DocsPlansTest {
         );
     }
 
-    private static List<String> workflowRunCommands(String workflow) {
-        List<String> runCommands = new ArrayList<>();
-        boolean explicitRunKey = false;
-        for (String rawLine : workflow.split("\\r?\\n")) {
-            String line = stripYamlComment(rawLine);
-            int contentStart = skipSpaces(line, 0);
-            if (contentStart == line.length()) {
-                continue;
-            }
-
-            if (explicitRunKey) {
-                if (line.charAt(contentStart) == ':') {
-                    runCommands.add("run: " + normalizeYamlScalar(line.substring(contentStart + 1)));
-                    explicitRunKey = false;
-                    continue;
-                }
-                explicitRunKey = false;
-            }
-
-            RunMapping blockMapping = parseRunMapping(line, contentStart, true);
-            if (blockMapping != null) {
-                if (blockMapping.explicit) {
-                    explicitRunKey = true;
-                } else {
-                    runCommands.add("run: " + blockMapping.value);
-                }
-            }
-
-            char quote = 0;
-            for (int index = contentStart; index < line.length(); index++) {
-                char current = line.charAt(index);
-                if (quote != 0) {
-                    if (current == quote) {
-                        if (quote == '\'' && index + 1 < line.length()
-                                && line.charAt(index + 1) == '\'') {
-                            index++;
-                        } else if (quote == '"' && index > 0 && line.charAt(index - 1) == '\\') {
-                            continue;
-                        } else {
-                            quote = 0;
-                        }
-                    }
-                    continue;
-                }
-                if (current == '\'' || current == '"') {
-                    quote = current;
-                } else if (current == '{' || current == ',') {
-                    RunMapping flowMapping = parseRunMapping(line, index + 1, false);
-                    if (flowMapping != null) {
-                        runCommands.add("run: " + flowMapping.value);
-                    }
-                }
-            }
+    private static String sha256Hex(byte[] bytes) throws NoSuchAlgorithmException {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+        StringBuilder hex = new StringBuilder(digest.length * 2);
+        for (byte value : digest) {
+            hex.append(String.format("%02x", value & 0xff));
         }
-        return runCommands;
-    }
-
-    private static RunMapping parseRunMapping(String line, int start, boolean allowSequenceMarker) {
-        int index = skipSpaces(line, start);
-        if (allowSequenceMarker && index < line.length() && line.charAt(index) == '-') {
-            index = skipSpaces(line, index + 1);
-        }
-
-        boolean explicit = false;
-        if (allowSequenceMarker && index < line.length() && line.charAt(index) == '?') {
-            explicit = true;
-            index = skipSpaces(line, index + 1);
-        }
-
-        ParsedScalar key = parseYamlScalar(line, index, true);
-        if (key == null || !"run".equals(key.value)) {
-            return null;
-        }
-
-        index = skipSpaces(line, key.end);
-        if (explicit && index == line.length()) {
-            return new RunMapping(true, "");
-        }
-        if (index >= line.length() || line.charAt(index) != ':') {
-            return null;
-        }
-
-        String value = line.substring(index + 1);
-        int flowEnd = findFlowValueEnd(value);
-        return new RunMapping(false, normalizeYamlScalar(value.substring(0, flowEnd)));
-    }
-
-    private static ParsedScalar parseYamlScalar(String line, int start, boolean key) {
-        if (start >= line.length()) {
-            return null;
-        }
-        char first = line.charAt(start);
-        if (first == '\'' || first == '"') {
-            StringBuilder value = new StringBuilder();
-            for (int index = start + 1; index < line.length(); index++) {
-                char current = line.charAt(index);
-                if (current == first) {
-                    if (first == '\'' && index + 1 < line.length()
-                            && line.charAt(index + 1) == '\'') {
-                        value.append('\'');
-                        index++;
-                        continue;
-                    }
-                    return new ParsedScalar(value.toString(), index + 1);
-                }
-                if (first == '"' && current == '\\' && index + 1 < line.length()) {
-                    value.append(line.charAt(++index));
-                } else {
-                    value.append(current);
-                }
-            }
-            return null;
-        }
-
-        int end = start;
-        while (end < line.length()) {
-            char current = line.charAt(end);
-            if (current == ':' || Character.isWhitespace(current)
-                    || current == ',' || current == '}' || current == ']') {
-                break;
-            }
-            end++;
-        }
-        if (end == start || (!key && end != line.length())) {
-            return null;
-        }
-        return new ParsedScalar(line.substring(start, end), end);
-    }
-
-    private static String normalizeYamlScalar(String scalar) {
-        String trimmed = scalar.trim();
-        ParsedScalar parsed = parseYamlScalar(trimmed, 0, false);
-        return parsed == null ? trimmed : parsed.value;
-    }
-
-    private static int findFlowValueEnd(String value) {
-        char quote = 0;
-        for (int index = 0; index < value.length(); index++) {
-            char current = value.charAt(index);
-            if (quote != 0) {
-                if (current == quote) {
-                    if (quote == '\'' && index + 1 < value.length()
-                            && value.charAt(index + 1) == '\'') {
-                        index++;
-                    } else if (quote != '"' || index == 0 || value.charAt(index - 1) != '\\') {
-                        quote = 0;
-                    }
-                }
-            } else if (current == '\'' || current == '"') {
-                quote = current;
-            } else if (current == ',' || current == '}') {
-                return index;
-            }
-        }
-        return value.length();
-    }
-
-    private static String stripYamlComment(String line) {
-        char quote = 0;
-        for (int index = 0; index < line.length(); index++) {
-            char current = line.charAt(index);
-            if (quote != 0) {
-                if (current == quote) {
-                    if (quote == '\'' && index + 1 < line.length()
-                            && line.charAt(index + 1) == '\'') {
-                        index++;
-                    } else if (quote != '"' || index == 0 || line.charAt(index - 1) != '\\') {
-                        quote = 0;
-                    }
-                }
-            } else if (current == '\'' || current == '"') {
-                quote = current;
-            } else if (current == '#'
-                    && (index == 0 || Character.isWhitespace(line.charAt(index - 1)))) {
-                return line.substring(0, index);
-            }
-        }
-        return line;
-    }
-
-    private static int skipSpaces(String value, int start) {
-        int index = start;
-        while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
-            index++;
-        }
-        return index;
-    }
-
-    private static final class ParsedScalar {
-        private final String value;
-        private final int end;
-
-        private ParsedScalar(String value, int end) {
-            this.value = value;
-            this.end = end;
-        }
-    }
-
-    private static final class RunMapping {
-        private final boolean explicit;
-        private final String value;
-
-        private RunMapping(boolean explicit, String value) {
-            this.explicit = explicit;
-            this.value = value;
-        }
+        return hex.toString();
     }
 }

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -34,6 +34,8 @@ public class DocsPlansTest {
             DOCS_PLANS.resolve("2026-06-13-strict-dial-form-parsing.md");
     private static final Path SUPPORTED_TOOLCHAIN_VERSIONS_PLAN =
             DOCS_PLANS.resolve("2026-06-14-supported-toolchain-versions.md");
+    private static final Path MAKE_AUTHORITY_PLAN =
+            DOCS_PLANS.resolve("2026-06-21-make-authority-hardening.md");
 
     @Test
     public void canonicalPlanIsCompletedAndVerified() throws IOException {
@@ -64,6 +66,7 @@ public class DocsPlansTest {
                 "supported toolchain versions plan must exist",
                 plans.contains(SUPPORTED_TOOLCHAIN_VERSIONS_PLAN)
         );
+        assertTrue("Make authority plan must exist", plans.contains(MAKE_AUTHORITY_PLAN));
 
         for (Path plan : plans) {
             String text = new String(Files.readAllBytes(plan), StandardCharsets.UTF_8);
@@ -86,15 +89,17 @@ public class DocsPlansTest {
 
         assertTrue(
                 "make check must run the scripted baseline guard from the repository root",
-                makefile.contains("\"$(ROOT)/scripts/check-baseline.sh\"")
+                makefile.contains("\"$$ROOT/scripts/check-baseline.sh\"")
         );
         assertTrue(
                 "ROOT must resist command-line reassignment",
-                makefile.contains("override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))")
+                makefile.contains("override ROOT := $(REPOSITORY_ROOT)")
         );
         assertFalse("ROOT must not depend on the caller's directory", makefile.contains("ROOT := $(CURDIR)"));
         assertTrue("the Maven executable must remain configurable", makefile.contains("MVN ?= mvn"));
-        assertTrue(makefile.contains("cd \"$(ROOT)\" && $(MVN)"));
+        assertTrue(makefile.contains("override MVN := $(value MVN)"));
+        assertTrue(makefile.contains("cd \"$$ROOT\" && $$MVN"));
+        assertTrue(makefile.contains("/bin/sh \"$$ROOT/scripts/test-makefile-authority.sh\""));
     }
 
     @Test

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
@@ -149,7 +150,17 @@ public class DocsPlansTest {
         assertTrue(workflow.contains("workflow_dispatch:"));
         assertTrue(workflow.contains("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"));
         assertTrue(workflow.contains("actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.1.0"));
-        assertTrue(workflow.contains("run: make check"));
+        List<String> runCommands = new ArrayList<>();
+        for (String line : workflow.split("\\r?\\n")) {
+            if (line.trim().startsWith("run:")) {
+                runCommands.add(line.trim());
+            }
+        }
+        assertEquals(
+                "workflow must use only the sanitized repository verification command",
+                Collections.singletonList("run: ./scripts/run-make.sh check"),
+                runCommands
+        );
         assertFalse("workflow must not use floating runners", workflow.contains("ubuntu-latest"));
         assertFalse("actions must use immutable commits", workflow.contains("@v"));
         assertFalse("workflow must not grant write permissions", workflow.matches(


### PR DESCRIPTION
## Summary

`make check` now remains authoritative when invoked from another directory or with hostile Make inputs. It rejects execution-skipping flags, startup-file injection, Makefile identity replacement, caller shell replacement, and Make-syntax Maven values while preserving literal multiword Maven command overrides.

## Baseline

The existing gate protected its repository root but still trusted several caller-controlled Make inputs. Those inputs could redirect or suppress verification without changing the checked-in Makefile.

## Improvements

- **Build and security:** bind the verification root and shell to the checked-in Makefile and fail closed on unsupported Make execution modes.
- **Tests:** add adversarial regression coverage for root, shell, Maven command, flags, startup files, and Makefile identity.
- **Documentation:** record supported Maven overrides and the GNU Make startup/later-`-f` trust boundary.

## Validation

- `./scripts/test-makefile-authority.sh` — passed
- sanitized repository-root `make check` — passed, 51 tests
- sanitized external-directory `make -f <exact-checkout>/Makefile check` — passed, 51 tests
- public Maven Central dependency resolution on Maven 3.6.3 / Java 8 — passed
- `make -n`, `make -t`, `make -q`, and `make -i` rejection probes — passed
- shell syntax, changed-file secret-pattern scan, and `git diff --check` — passed

All validation kept Twilio credentials unset, disabled live dialing, and made no provider calls.

## Risk

- No Java behavior, dependency version, provider request, publishing, or deployment behavior changes.
- GNU Make startup files execute before a Makefile can reject them, and later caller-supplied `-f` files remain outside the documented authority boundary.

## Follow-Ups

- None required for this focused hardening slice.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes only local/CI verification authority and does not alter runtime or deployed behavior. The required Java 8/11/17/21 checks on this pull request are the release signal; any failure blocks adoption.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
