### PR TITLE
Reject malformed UTF-8 dial form bytes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@
 ## Safety and gotchas
 
 - Detected references to Twilio. Keep API keys, OAuth credentials, tokens, and account-specific values in local configuration only.
+- Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-twilio-java-rc-testing-baseline.md` for the canonical dry-run dialing and verification baseline.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,39 @@
 # Changes
 
+## 2026-06-25 08:15 PDT - P2 - Reject malformed UTF-8 form bytes
+
+### Summary
+The dial route now rejects malformed raw UTF-8 before parsing or ignoring form fields.
+
+### Work completed
+- Added a loopback integration test proving raw and percent-encoded malformed UTF-8 in an unknown field previously returned a successful dry run.
+- Switched the bounded request body to a reporting UTF-8 decoder before form tokenization.
+- Added baseline and documentation contracts for the fail-closed decoding boundary.
+
+### Threads
+- None; work completed directly in this maintenance cycle.
+
+### Files changed
+- `Main.java` and `MainTest.java` — strict decoding and route-level regression coverage.
+- `scripts/`, maintained docs, and `docs/plans/` — portable contracts and evidence.
+
+### Validation
+- Focused malformed-UTF-8 integration test — failed with HTTP 200 before the fix and passed with HTTP 400 afterward.
+- Full repository and external-directory `make check` — passed with 53 tests on Maven 3.6.3 and Java 21.
+- Hostile permissive-decoder mutation — rejected by the canonical baseline.
+- Codex review found and drove closure of the percent-encoded malformed UTF-8 path before merge.
+
+### Bugs / findings
+- P2: Java's replacement-character decoding allowed malformed raw UTF-8 in ignored fields to bypass strict form rejection.
+
+### Blockers
+- None.
+
+### Next action
+- Open the PR, run Codex review, and merge only after hosted checks pass.
+
+Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.
+
 - Hardened `make check` against Make-syntax Maven expansion, caller shell and
   Makefile identity replacement, execution-skipping flags, and startup-file
   configuration while preserving literal multiword Maven overrides.

--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   a repeated live request ID before provider access, retains accepted IDs in a
   bounded process-local ledger, and does not retry Twilio call-creation POSTs.
   Connect and response timeouts are five and ten seconds respectively.
-- Duplicate `number`, `dialToken`, or `requestId` fields, malformed pairs, and malformed percent encoding are
+- Duplicate `number`, `dialToken`, or `requestId` fields, malformed pairs,
+  malformed UTF-8 bytes, and malformed percent encoding are
   rejected with a generic `400` before authorization or provider setup; unknown
   form fields remain ignored for browser compatibility.
+- Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.
 - `NGROK_URL` must be a valid HTTPS origin URL with a host, without path,
   query, fragment, or userinfo, before the app builds a TwiML callback URL.
 - The `/twiml` route returns TwiML XML with an explicit `application/xml`
@@ -136,7 +138,7 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   exception details.
 - Tests require oversized dial forms to return `413` before parsing or dialing.
 - Tests require one-pass dial-form parsing to reject duplicate relevant fields
-  and malformed percent encoding before authorization or provider setup.
+  and malformed UTF-8 or percent encoding before authorization or provider setup.
 - Tests require `/dial-phone` to accept the exact form media type, including
   case-insensitive parameterized variants, while rejecting missing, unrelated,
   and spoofed-prefix content types with `415`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,9 +52,10 @@ minute, before form parsing or token comparison. This bounds token guessing and
 accidental call volume but is not a distributed control and does not replace
 Twilio account spend limits or deployment-level abuse protection.
 
-The dial form rejects duplicate phone-number or authorization-token fields and
-malformed percent encoding before authorization or provider configuration.
-Unknown fields are ignored, but relevant fields must be unique and decodable.
+The dial form rejects duplicate phone-number or authorization-token fields,
+malformed UTF-8 bytes, and malformed percent encoding before authorization or
+provider configuration. Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.
+Unknown well-formed fields are ignored, but relevant fields must be unique and decodable.
 
 HTTP responses use `no-store`, framing denial, a no-referrer policy, a
 restrictive Content Security Policy, and disabled camera/geolocation/microphone

--- a/VISION.md
+++ b/VISION.md
@@ -35,6 +35,7 @@ Priority:
 - Bound live dial attempts before form parsing or authorization checks
 - Reject duplicate or malformed security-relevant dial form fields before
   authorization and provider configuration
+- Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.
 - Keep loopback integration coverage around request limits and malformed forms
 - Keep the injectable Twilio call-sender boundary covered by local tests
 - Keep live-call authorization, rate limiting, request-ID deduplication, and

--- a/docs/plans/2026-06-25-strict-form-utf8.md
+++ b/docs/plans/2026-06-25-strict-form-utf8.md
@@ -1,0 +1,29 @@
+# Strict Form UTF-8 Decoding
+
+## Status: Completed
+
+## Problem
+
+The bounded dial form body and percent-decoded components used Java's
+replacement-character UTF-8 behavior. Malformed raw or percent-encoded bytes
+in an unknown field could therefore be ignored and a valid dry-run request
+could still return HTTP 200.
+
+## Design
+
+- Decode the complete bounded body with a reporting UTF-8 decoder before form tokenization.
+- Return the existing generic invalid-form HTTP 400 for malformed or unmappable bytes.
+- Keep unknown well-formed fields ignored for browser compatibility.
+- Preserve body-size, media-type, authorization, configuration, rate-limit, and provider boundaries.
+
+## Test-First Evidence
+
+- RED: malformed raw and percent-encoded UTF-8 in an ignored field returned HTTP 200 and a dry-run response.
+- GREEN: both requests return the generic HTTP 400 before field filtering.
+
+## Verification
+
+- The focused loopback integration test passed after the fix.
+- Full repository and external-directory `make check` passed with 53 tests.
+- A hostile mutation restoring replacement-character decoding was rejected by the canonical baseline.
+- No Twilio credentials were loaded and no live call was made.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -44,6 +44,7 @@ for path in \
   "docs/plans/2026-06-14-supported-toolchain-versions.md" \
   "docs/plans/2026-06-19-live-dial-at-most-once.md" \
   "docs/plans/2026-06-21-make-authority-hardening.md" \
+  "docs/plans/2026-06-25-strict-form-utf8.md" \
   "scripts/run-make.sh" \
   "scripts/test-makefile-authority.sh" \
   "scripts/test-workflow-authority.sh" \
@@ -190,6 +191,9 @@ PY
 
 for strict_form_contract in \
   'private static DialForm parseDialForm(byte[] body) throws InvalidFormException' \
+  'onMalformedInput(CodingErrorAction.REPORT)' \
+  'onUnmappableCharacter(CodingErrorAction.REPORT)' \
+  'catch (CharacterCodingException invalidEncoding)' \
   'String name = decodeFormComponent(parts[0]);' \
   'if (name == null)' \
   'if (!"number".equals(name) && !"dialToken".equals(name) && !"requestId".equals(name))' \
@@ -201,10 +205,19 @@ for strict_form_contract in \
   'throw new InvalidFormException();' \
   'sendResponse(exchange, 400, "text/plain; charset=utf-8", "Invalid form submission.")' \
   'dialPhoneRouteRejectsAmbiguousOrMalformedRelevantFormFields' \
+  'dialPhoneRouteRejectsMalformedUtf8BeforeIgnoringUnknownFields' \
   'dialPhoneRouteIgnoresUnknownFormFields'; do
   if ! grep -Fq -- "$strict_form_contract" "$ROOT_DIR/src/main/java/org/example/Main.java" && \
      ! grep -Fq -- "$strict_form_contract" "$ROOT_DIR/src/test/java/org/example/MainTest.java"; then
     printf '%s\n' "Strict dial form contract is missing: $strict_form_contract" >&2
+    exit 1
+  fi
+done
+
+strict_utf8_guidance='Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.'
+for strict_utf8_doc in AGENTS.md README.md SECURITY.md VISION.md CHANGES.md; do
+  if ! grep -Fq -- "$strict_utf8_guidance" "$ROOT_DIR/$strict_utf8_doc"; then
+    printf '%s\n' "$strict_utf8_doc must document strict UTF-8 decoding before unknown-field filtering." >&2
     exit 1
   fi
 done
@@ -236,6 +249,9 @@ unknown = re.search(
 )
 if unknown is None:
     raise SystemExit("Unknown dial form fields must remain ignored.")
+value_decode = body.find("String value = decodeFormComponent(parts[1]);")
+if value_decode < 0 or value_decode > unknown.start():
+    raise SystemExit("Dial form values must be decoded before unknown fields are ignored.")
 PY
 
 for authorization_order_contract in \

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -23,7 +23,9 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -444,7 +446,16 @@ public class Main {
     }
 
     private static DialForm parseDialForm(byte[] body) throws InvalidFormException {
-        String form = new String(body, StandardCharsets.UTF_8);
+        String form;
+        try {
+            form = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(body))
+                    .toString();
+        } catch (CharacterCodingException invalidEncoding) {
+            throw new InvalidFormException();
+        }
         String phoneNumber = null;
         String dialToken = null;
         String requestId = null;
@@ -457,12 +468,12 @@ public class Main {
             if (name == null) {
                 throw new InvalidFormException();
             }
-            if (!"number".equals(name) && !"dialToken".equals(name) && !"requestId".equals(name)) {
-                continue;
-            }
             String value = decodeFormComponent(parts[1]);
             if (value == null) {
                 throw new InvalidFormException();
+            }
+            if (!"number".equals(name) && !"dialToken".equals(name) && !"requestId".equals(name)) {
+                continue;
             }
             if ("number".equals(name)) {
                 if (phoneNumber != null) {
@@ -496,11 +507,42 @@ public class Main {
     }
 
     private static String decodeFormComponent(String value) {
-        try {
-            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
-        } catch (IllegalArgumentException | IOException invalidEncoding) {
-            return null;
+        StringBuilder decoded = new StringBuilder();
+        for (int index = 0; index < value.length();) {
+            char character = value.charAt(index);
+            if (character == '+') {
+                decoded.append(' ');
+                index++;
+                continue;
+            }
+            if (character != '%') {
+                decoded.append(character);
+                index++;
+                continue;
+            }
+            ByteArrayOutputStream escapedBytes = new ByteArrayOutputStream();
+            while (index < value.length() && value.charAt(index) == '%') {
+                if (index + 2 >= value.length()) {
+                    return null;
+                }
+                int high = Character.digit(value.charAt(index + 1), 16);
+                int low = Character.digit(value.charAt(index + 2), 16);
+                if (high < 0 || low < 0) {
+                    return null;
+                }
+                escapedBytes.write((high << 4) + low);
+                index += 3;
+            }
+            try {
+                decoded.append(StandardCharsets.UTF_8.newDecoder()
+                        .onMalformedInput(CodingErrorAction.REPORT)
+                        .onUnmappableCharacter(CodingErrorAction.REPORT)
+                        .decode(ByteBuffer.wrap(escapedBytes.toByteArray())));
+            } catch (CharacterCodingException invalidEncoding) {
+                return null;
+            }
         }
+        return decoded.toString();
     }
 
     private static void sendResponse(

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -38,6 +38,8 @@ public class DocsPlansTest {
             DOCS_PLANS.resolve("2026-06-14-supported-toolchain-versions.md");
     private static final Path MAKE_AUTHORITY_PLAN =
             DOCS_PLANS.resolve("2026-06-21-make-authority-hardening.md");
+    private static final Path STRICT_FORM_UTF8_PLAN =
+            DOCS_PLANS.resolve("2026-06-25-strict-form-utf8.md");
 
     @Test
     public void canonicalPlanIsCompletedAndVerified() throws IOException {
@@ -69,6 +71,7 @@ public class DocsPlansTest {
                 plans.contains(SUPPORTED_TOOLCHAIN_VERSIONS_PLAN)
         );
         assertTrue("Make authority plan must exist", plans.contains(MAKE_AUTHORITY_PLAN));
+        assertTrue("strict form UTF-8 plan must exist", plans.contains(STRICT_FORM_UTF8_PLAN));
 
         for (Path plan : plans) {
             String text = new String(Files.readAllBytes(plan), StandardCharsets.UTF_8);

--- a/src/test/java/org/example/MainTest.java
+++ b/src/test/java/org/example/MainTest.java
@@ -16,6 +16,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -315,6 +316,47 @@ public class MainTest {
             Main.accountSid = originalAccountSid;
             Main.authToken = originalAuthToken;
             Main.resetLiveDialRateLimit();
+        }
+    }
+
+    @Test
+    public void dialPhoneRouteRejectsMalformedUtf8BeforeIgnoringUnknownFields() throws Exception {
+        String originalNumber = Main.twilioNumber;
+        String originalBaseUrl = Main.NGROK_BASE_URL;
+        String originalSendLive = Main.TWILIO_SEND_LIVE;
+        HttpServer server = Main.startServer(0);
+        try {
+            Main.twilioNumber = "+15551234567";
+            Main.NGROK_BASE_URL = "https://example.ngrok.io";
+            Main.TWILIO_SEND_LIVE = "false";
+            byte[] prefix = "number=%2B15557654321&ignored=".getBytes(StandardCharsets.UTF_8);
+            byte[] body = Arrays.copyOf(prefix, prefix.length + 2);
+            body[prefix.length] = (byte) 0xc3;
+            body[prefix.length + 1] = (byte) 0x28;
+
+            HttpResponse response = requestBytes(
+                    server.getAddress().getPort(),
+                    "POST",
+                    "/dial-phone",
+                    body,
+                    "application/x-www-form-urlencoded; charset=utf-8"
+            );
+            HttpResponse percentEncoded = request(
+                    server.getAddress().getPort(),
+                    "POST",
+                    "/dial-phone",
+                    "number=%2B15557654321&ignored=%C3%28"
+            );
+
+            assertEquals(400, response.status);
+            assertEquals("Invalid form submission.", response.body);
+            assertEquals(400, percentEncoded.status);
+            assertEquals("Invalid form submission.", percentEncoded.body);
+        } finally {
+            server.stop(0);
+            Main.twilioNumber = originalNumber;
+            Main.NGROK_BASE_URL = originalBaseUrl;
+            Main.TWILIO_SEND_LIVE = originalSendLive;
         }
     }
 
@@ -942,14 +984,29 @@ public class MainTest {
             String body,
             String contentType
     ) throws Exception {
+        return requestBytes(
+                port,
+                method,
+                path,
+                body == null ? null : body.getBytes(StandardCharsets.UTF_8),
+                contentType
+        );
+    }
+
+    private static HttpResponse requestBytes(
+            int port,
+            String method,
+            String path,
+            byte[] bodyBytes,
+            String contentType
+    ) throws Exception {
         HttpURLConnection connection = (HttpURLConnection) new URL(
                 "http://127.0.0.1:" + port + path
         ).openConnection();
         connection.setRequestMethod(method);
         connection.setConnectTimeout(LOOPBACK_TIMEOUT_MILLIS);
         connection.setReadTimeout(LOOPBACK_TIMEOUT_MILLIS);
-        if (body != null) {
-            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+        if (bodyBytes != null) {
             connection.setDoOutput(true);
             if (contentType != null) {
                 connection.setRequestProperty("Content-Type", contentType);


### PR DESCRIPTION
## Summary
- decode the complete bounded dial form with a fail-closed UTF-8 decoder before tokenization
- reject malformed raw bytes before unknown-field filtering while preserving compatible unknown fields
- add loopback regression, portable baseline contracts, mutation evidence, and maintenance documentation

## Verification
- focused test failed with HTTP 200 before the fix and passed with HTTP 400 afterward
- root and external-directory `make check` with Maven 3.6.3 / Java 21
- 53 JUnit tests
- Make and workflow authority suites
- hostile permissive-decoder mutation rejected

No Twilio credentials were loaded and no live call was made.
