### PR TITLE
Document fail-closed debug log redaction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@ identifiers, request data, or callback origins.
 - Twelve hostile mutations removing the guide, plan, index links, or required
   redaction topics were rejected by `scripts/check-baseline.sh`.
 - `git diff --check` passed.
+- Hosted Java 8/11/17/21 verification, CodeQL, and Snyk checks passed on the PR.
+- `codex review --base origin/main` was attempted but could not authenticate
+  to the review service (HTTP 401); the run continued under the standing
+  instruction to skip skill authentication issues.
 
 ### Bugs / findings
 - P2: Existing guidance warned that debug logs could expose call metadata but
@@ -40,10 +44,12 @@ identifiers, request data, or callback origins.
   uncertain credential exposure.
 
 ### Blockers
-- None.
+- The external Codex review service is unavailable to this environment because
+  its bearer authentication is missing. This does not block the locally and
+  hosted-validated documentation change.
 
 ### Next action
-- Open the PR, run Codex review, and merge only after hosted checks pass.
+- Merge the exact green PR head into `main`.
 
 ## 2026-06-25 08:15 PDT - P2 - Reject malformed UTF-8 form bytes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,50 @@
 # Changes
 
+## 2026-06-25 23:52 PDT - P2 - Close debug-log redaction roadmap item
+
+### Summary
+Operators now have a fail-closed checklist for collecting and sharing local
+diagnostics without exposing Twilio credentials, phone numbers, provider
+identifiers, request data, or callback origins.
+
+### Work completed
+- Added an allowlist-first debug-log guide with explicit forbidden fields,
+  sanitized examples, pre-sharing review steps, and credential-rotation action.
+- Linked the guide from runtime and security documentation and closed the final
+  queued roadmap item.
+- Added JUnit and shell contracts requiring the guide, completed plan, index
+  links, and security-critical topics.
+
+### Threads
+- None; work completed directly in this maintenance cycle.
+
+### Files changed
+- `docs/debug-log-redaction.md` and `docs/plans/2026-06-25-debug-log-redaction.md`
+  — operator guidance and completed implementation evidence.
+- `README.md`, `SECURITY.md`, `VISION.md`, and `CHANGES.md` — discoverability,
+  security posture, roadmap state, and cycle record.
+- `DocsPlansTest.java` and `scripts/check-baseline.sh` — fail-closed contracts.
+
+### Validation
+- Red phase: `scripts/check-baseline.sh` rejected the missing guide before the
+  documentation was added.
+- `MVN=/tmp/apache-maven-3.6.3/bin/mvn scripts/run-make.sh check` passed with
+  54 tests on Java 21 and the documented Maven 3.6.3 baseline.
+- Twelve hostile mutations removing the guide, plan, index links, or required
+  redaction topics were rejected by `scripts/check-baseline.sh`.
+- `git diff --check` passed.
+
+### Bugs / findings
+- P2: Existing guidance warned that debug logs could expose call metadata but
+  did not define what to remove, what was safe to retain, or how to respond to
+  uncertain credential exposure.
+
+### Blockers
+- None.
+
+### Next action
+- Open the PR, run Codex review, and merge only after hosted checks pass.
+
 ## 2026-06-25 08:15 PDT - P2 - Reject malformed UTF-8 form bytes
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   unused browser capabilities, and applies a restrictive Content Security
   Policy that permits only the existing Bootstrap stylesheet origin.
 - Runtime logging defaults to `info`; switch to debug only in a local working
-  copy when you are prepared to redact call metadata before sharing logs.
+  copy and follow [`docs/debug-log-redaction.md`](docs/debug-log-redaction.md)
+  before sharing any diagnostic output.
 
 ## Testing and Verification
 
@@ -200,6 +201,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   Maven, and Twilio SDK support boundary.
 - See `docs/plans/2026-06-21-make-authority-hardening.md` for the canonical
   wrapper, Maven command, shell, flag, startup-file, and Makefile authority.
+- See `docs/debug-log-redaction.md` and
+  `docs/plans/2026-06-25-debug-log-redaction.md` for the fail-closed diagnostic
+  sharing checklist and its executable repository contract.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,11 @@ malformed UTF-8 bytes, and malformed percent encoding before authorization or
 provider configuration. Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.
 Unknown well-formed fields are ignored, but relevant fields must be unique and decodable.
 
+Checked-in logging stays at `info`. Before enabling local diagnostics or
+sharing any log excerpt, follow [`docs/debug-log-redaction.md`](docs/debug-log-redaction.md).
+It treats credentials, request bodies, phone numbers, Twilio identifiers,
+callback origins, and unreviewed provider exceptions as non-shareable data.
+
 HTTP responses use `no-store`, framing denial, a no-referrer policy, a
 restrictive Content Security Policy, and disabled camera/geolocation/microphone
 capabilities. Keep these controls aligned with any future UI asset changes.

--- a/VISION.md
+++ b/VISION.md
@@ -49,10 +49,12 @@ Priority:
   restrictive browser security policy
 - Keep TwiML callback responses explicit and testable
 - Keep checked-in runtime logging at info by default
+- Keep debug diagnostics allowlisted, locally scoped, and redacted before
+  sharing
 
 Next priorities:
 
-- Add explicit debug-log redaction guidance
+- No additional roadmap item is currently queued.
 
 Contribution rules:
 

--- a/docs/debug-log-redaction.md
+++ b/docs/debug-log-redaction.md
@@ -1,0 +1,81 @@
+# Debug Log Redaction
+
+The checked-in application keeps Log4j at `info`, installs an inert SLF4J
+binding for dependency logging, and does not emit request or provider
+diagnostics. Keep that default. This guide applies when an operator temporarily
+adds local diagnostics, enables dependency logging, or collects reverse-proxy
+or platform logs while troubleshooting.
+
+Twilio recommends treating credentials like passwords and keeping them outside
+source code. Phone numbers and account identifiers are also unnecessary for
+most debugging and can be personal or account-linked data. Start in dry-run
+mode whenever the failure can be reproduced without placing a call.
+
+## Never log or share
+
+- `TWILIO_AUTH_TOKEN`, `TWILIO_DIAL_TOKEN`, authorization headers, cookies, or
+  any other secret. Replace the entire value with `[redacted-secret]`; retaining
+  a prefix or suffix is not useful for diagnosis.
+- Raw request bodies, form bodies, query strings, or complete HTTP request and
+  response dumps. These can contain tokens, phone numbers, callback URLs, and
+  future fields not anticipated by a filter.
+- Full source or destination phone numbers. If a case truly requires matching
+  one number across sanitized lines, preserve only the final four characters,
+  matching the application's response redaction: `****1234`.
+- Full Account SIDs, API key SIDs, Call SIDs, request IDs, or other provider and
+  correlation identifiers. Use a type label such as `[redacted-call-sid]`.
+- The configured ngrok or callback origin, URL user information, URL paths,
+  fragments, or query parameters. Use `[redacted-callback-origin]`.
+- Provider response bodies or exception messages and stack traces until every
+  line has been reviewed. Record a stable local category such as
+  `provider-call-failed` instead of an exception message.
+- Environment dumps, command histories, process listings, heap dumps, or
+  screenshots that may contain the configured environment variables.
+
+## Safe diagnostic fields
+
+Prefer a small allowlist rather than trying to remove sensitive fields from a
+large object. Fixed event names, route names, HTTP status codes, dry-run versus
+live mode, elapsed time, and generic outcomes are normally sufficient. Counts
+and rate-limit decisions are safe when they cannot identify a caller.
+
+If local correlation is essential, generate a new case label that is unrelated
+to the application's request ID or Twilio identifiers. Do not publish the
+mapping. Avoid logging Java objects from the Twilio SDK or HTTP client because
+their string representations are not a stable redaction boundary.
+
+Example sanitized record:
+
+```text
+event=dial-attempt mode=dry-run outcome=invalid-target status=400 case=local-2
+```
+
+## Before sharing a log
+
+1. Reproduce in dry-run mode and keep the checked-in `info` default whenever
+   possible. Capture only the shortest useful interval.
+2. Copy only the relevant lines into a new text file. Never share the original
+   log, an archive of the log directory, or a complete platform export.
+3. Replace secrets and identifiers using the rules above, then search the copy
+   for the literal configured environment values.
+4. Search for Twilio SID shapes such as `AC` or `CA` followed by 32 hexadecimal
+   characters, E.164-like values beginning with `+`, `Authorization`, `token`,
+   `password`, form field names, URL query delimiters, and multiline stack
+   traces. Pattern searches are a backstop, not permission to share a match.
+5. Ask a second person to review the sanitized copy when it came from a live
+   request or production-like environment.
+6. Delete temporary debug changes and sanitized working files when the issue is
+   closed. Return logging to the repository default before committing.
+
+Rotate credentials immediately if a secret may have appeared in a log,
+screenshot, issue, chat, or artifact. Rotate `TWILIO_AUTH_TOKEN` through the
+Twilio Console and replace `TWILIO_DIAL_TOKEN` everywhere it is configured.
+Treat uncertain exposure as exposure; deleting a public post does not revoke a
+credential.
+
+## References
+
+- [Secure your Twilio credentials](https://www.twilio.com/docs/usage/secure-credentials)
+- [Twilio security guidance](https://www.twilio.com/docs/usage/security)
+- [Twilio Auth Tokens and how to change them](https://help.twilio.com/articles/223136027)
+

--- a/docs/debug-log-redaction.md
+++ b/docs/debug-log-redaction.md
@@ -78,4 +78,3 @@ credential.
 - [Secure your Twilio credentials](https://www.twilio.com/docs/usage/secure-credentials)
 - [Twilio security guidance](https://www.twilio.com/docs/usage/security)
 - [Twilio Auth Tokens and how to change them](https://help.twilio.com/articles/223136027)
-

--- a/docs/plans/2026-06-25-debug-log-redaction.md
+++ b/docs/plans/2026-06-25-debug-log-redaction.md
@@ -34,4 +34,3 @@ make safe local troubleshooting and log sharing explicit.
 - `scripts/check-baseline.sh` fails when the guide, plan, index links, or
   required redaction topics are absent.
 - `make check` verifies the complete Maven and repository baseline.
-

--- a/docs/plans/2026-06-25-debug-log-redaction.md
+++ b/docs/plans/2026-06-25-debug-log-redaction.md
@@ -1,0 +1,37 @@
+# Debug Log Redaction Guidance
+
+Status: Completed
+
+## Context
+
+The repository already keeps checked-in logging at `info`, prevents provider
+failure details from reaching HTTP responses, redacts dial targets in response
+messages, and uses an inert SLF4J binding. The remaining roadmap item was to
+make safe local troubleshooting and log sharing explicit.
+
+## Scope
+
+- Document a fail-closed list of credentials, request data, phone numbers,
+  Twilio identifiers, callback origins, and exception details that must not be
+  logged or shared.
+- Prefer an allowlist of generic diagnostic fields over object or payload dumps.
+- Define a review checklist and credential-rotation response for possible
+  exposure.
+- Keep the guide indexed from operator and security documentation.
+- Add executable repository contracts so the guidance cannot silently vanish.
+
+## Completed work
+
+- Added `docs/debug-log-redaction.md` with safe-field examples, forbidden data,
+  a pre-sharing checklist, and incident response guidance.
+- Linked the guide from `README.md` and `SECURITY.md`.
+- Closed the roadmap item in `VISION.md` and recorded the cycle in `CHANGES.md`.
+- Added JUnit and shell baseline contracts for the guide, its plan, and its
+  security-critical topics.
+
+## Verification
+
+- `scripts/check-baseline.sh` fails when the guide, plan, index links, or
+  required redaction topics are absent.
+- `make check` verifies the complete Maven and repository baseline.
+

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -30,6 +30,7 @@ for path in \
   "src/main/java/org/example/Main.java" \
   "src/test/java/org/example/DocsPlansTest.java" \
   "src/test/java/org/example/MainTest.java" \
+  "docs/debug-log-redaction.md" \
   "docs/plans/2026-06-08-twilio-java-rc-testing-baseline.md" \
   "docs/plans/2026-06-09-scripted-baseline-check.md" \
   "docs/plans/2026-06-10-dependencies-and-ci.md" \
@@ -45,11 +46,34 @@ for path in \
   "docs/plans/2026-06-19-live-dial-at-most-once.md" \
   "docs/plans/2026-06-21-make-authority-hardening.md" \
   "docs/plans/2026-06-25-strict-form-utf8.md" \
+  "docs/plans/2026-06-25-debug-log-redaction.md" \
   "scripts/run-make.sh" \
   "scripts/test-makefile-authority.sh" \
   "scripts/test-workflow-authority.sh" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
+done
+
+for debug_log_contract in \
+  'Never log or share' \
+  'TWILIO_AUTH_TOKEN' \
+  'TWILIO_DIAL_TOKEN' \
+  'request bodies' \
+  'phone numbers' \
+  'Call SID' \
+  'Rotate credentials' \
+  'dry-run mode'; do
+  if ! grep -Fq -- "$debug_log_contract" "$ROOT_DIR/docs/debug-log-redaction.md"; then
+    printf '%s\n' "Debug-log redaction guidance is missing: $debug_log_contract" >&2
+    exit 1
+  fi
+done
+
+for debug_log_index in README.md SECURITY.md; do
+  if ! grep -Fq 'docs/debug-log-redaction.md' "$ROOT_DIR/$debug_log_index"; then
+    printf '%s\n' "$debug_log_index must index debug-log redaction guidance." >&2
+    exit 1
+  fi
 done
 
 for loopback_timeout_contract in \

--- a/src/test/java/org/example/DocsPlansTest.java
+++ b/src/test/java/org/example/DocsPlansTest.java
@@ -40,6 +40,8 @@ public class DocsPlansTest {
             DOCS_PLANS.resolve("2026-06-21-make-authority-hardening.md");
     private static final Path STRICT_FORM_UTF8_PLAN =
             DOCS_PLANS.resolve("2026-06-25-strict-form-utf8.md");
+    private static final Path DEBUG_LOG_REDACTION_PLAN =
+            DOCS_PLANS.resolve("2026-06-25-debug-log-redaction.md");
 
     @Test
     public void canonicalPlanIsCompletedAndVerified() throws IOException {
@@ -72,6 +74,7 @@ public class DocsPlansTest {
         );
         assertTrue("Make authority plan must exist", plans.contains(MAKE_AUTHORITY_PLAN));
         assertTrue("strict form UTF-8 plan must exist", plans.contains(STRICT_FORM_UTF8_PLAN));
+        assertTrue("debug-log redaction plan must exist", plans.contains(DEBUG_LOG_REDACTION_PLAN));
 
         for (Path plan : plans) {
             String text = new String(Files.readAllBytes(plan), StandardCharsets.UTF_8);
@@ -188,6 +191,24 @@ public class DocsPlansTest {
         assertTrue(pom.contains("<artifactId>twilio</artifactId>"));
         assertTrue(pom.contains("<version>12.1.1</version>"));
         assertTrue(workflow.contains("java-version: [\"8\", \"11\", \"17\", \"21\"]"));
+    }
+
+    @Test
+    public void debugLogSharingGuidanceRemainsFailClosed() throws IOException {
+        String guide = read("docs/debug-log-redaction.md");
+        String readme = read("README.md");
+        String security = read("SECURITY.md");
+
+        assertTrue(guide.contains("Never log or share"));
+        assertTrue(guide.contains("TWILIO_AUTH_TOKEN"));
+        assertTrue(guide.contains("TWILIO_DIAL_TOKEN"));
+        assertTrue(guide.contains("request bodies"));
+        assertTrue(guide.contains("phone numbers"));
+        assertTrue(guide.contains("Call SID"));
+        assertTrue(guide.contains("Rotate credentials"));
+        assertTrue(guide.contains("dry-run mode"));
+        assertTrue(readme.contains("docs/debug-log-redaction.md"));
+        assertTrue(security.contains("docs/debug-log-redaction.md"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add an allowlist-first guide for collecting and sharing local diagnostics
- explicitly forbid credentials, request bodies, phone numbers, Twilio identifiers, callback origins, and unreviewed provider errors

## Baseline
- diagnostic sharing guidance did not define a fail-closed allowlist for sensitive Twilio and customer data

## Improvements
- close the roadmap item and add JUnit plus shell contracts that reject weakened guidance

## Validation
- repository `make check` passed 54 tests
- 12 hostile documentation mutations and `git diff --check` passed

## Risk
- documentation and contracts reduce accidental disclosure but cannot sanitize diagnostics collected outside the prescribed workflow

## Follow-Ups
- keep the allowlist synchronized with future diagnostic fields and provider integrations
- references: https://www.twilio.com/docs/usage/secure-credentials and https://www.twilio.com/docs/usage/security
