### PR TITLE
fix: preserve live dial quota on clock rollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 
 - Detected references to Twilio. Keep API keys, OAuth credentials, tokens, and account-specific values in local configuration only.
 - Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.
+- Backward wall-clock adjustments must not reset the authorized live dial quota.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-twilio-java-rc-testing-baseline.md` for the canonical dry-run dialing and verification baseline.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,62 @@
 # Changes
 
+## 2026-06-26 12:28 PDT - P1 - Preserve live-call quota across clock rollback
+
+### Summary
+Kept the process-local authorized live dial quota fail closed when the wall
+clock moves backward, and corrected stale security documentation that still
+claimed unauthorized requests consumed quota.
+
+### Work completed
+- Added a red-first limiter regression covering exhausted quota, backward time,
+  the original expiry boundary, and recovery after a full minute.
+- Replaced rollback-as-reset behavior with a conservative elapsed-window check
+  that also treats signed subtraction overflow as elapsed.
+- Corrected README, security, vision, and maintainer guidance: rate limiting is
+  enforced after strict parsing, exact authorization, and provider validation,
+  so it bounds authorized call volume rather than token guessing.
+- Extended static contracts and added a completed implementation plan.
+
+### Threads
+- Started: live dial clock rollback — direct implementation.
+- Continued: continuous open-source maintenance loop.
+- Stopped: none.
+
+### Files changed
+- `src/main/java/org/example/Main.java` — fail-closed fixed-window expiry.
+- `src/test/java/org/example/MainTest.java` — backward-clock regression.
+- `scripts/check-baseline.sh` — source, test, plan, and documentation contracts.
+- `README.md`, `SECURITY.md`, `VISION.md`, `AGENTS.md` — accurate quota scope.
+- `docs/plans/2026-06-26-live-dial-clock-rollback.md` — completed plan.
+- `CHANGES.md` — this cycle record.
+
+### Validation
+- Red JUnit test — the third acquisition at an earlier timestamp was accepted
+  before the fix and is now rejected.
+- Maven 3.9.11 / Java 21 `make check` — Make authority, nine workflow
+  mutations, compile, 55 JUnit tests, package, and scripted baseline passed.
+- Three isolated hostile mutations — rollback reset, missing regression
+  contract, and restored stale public guidance all failed closed.
+- Runtime dependency-tree resolution and `git diff --check` passed.
+- Hosted runs `28260295480` and `28260297600` passed Java 8, 11, 17, and 21.
+- CodeQL run `28260296292` passed Actions and Java/Kotlin analysis; the
+  aggregate CodeQL check and Snyk PR check also passed.
+- `codex review --base origin/main` was attempted on exact head `75d5c00` but
+  OpenAI authentication returned HTTP 401 before analysis; immutable manual
+  diff review found no accepted or actionable findings.
+
+### Bugs / findings
+- P1: A backward wall-clock adjustment cleared exhausted authorized-call quota.
+- P1: Public guidance incorrectly claimed the authorization-first limiter
+  bounded online token guessing and ran before form parsing.
+
+### Blockers
+- None. Tests use an injected clock and fake call sender; no live call occurs.
+
+### Next action
+- Run the full Maven gate and hostile mutations, then require exact-head hosted
+  checks and review before merge.
+
 ## 2026-06-25 23:52 PDT - P2 - Close debug-log redaction roadmap item
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   Live requests check that token before returning detailed Twilio credential,
   sender, or callback-origin configuration errors; dry runs remain
   unauthenticated and credential-free.
-- Tests limit the process to five live dial attempts per minute before form
-  parsing or token comparison. Exhausted requests return `429` with
-  `Retry-After: 60`; dry runs are not rate-limited.
+- Tests limit the process to five fully validated, authorized live dial
+  attempts per minute after strict form parsing, token comparison, and provider
+  configuration validation. Exhausted requests return `429` with
+  `Retry-After: 60`; dry runs and unauthorized requests do not consume the
+  authorized live dial quota. Backward wall-clock adjustments cannot reset it.
 - Tests require provider failures to return a generic `502` without leaking
   exception details.
 - Tests require oversized dial forms to return `413` before parsing or dialing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,10 +47,13 @@ Live `/dial-phone` requests require the separately configured
 `TWILIO_DIAL_TOKEN`. Use a high-entropy value, do not place it in URLs or source
 control, and rotate it if a submitted form or request log may have exposed it.
 
-The sample also permits at most five live dial attempts per process each
-minute, before form parsing or token comparison. This bounds token guessing and
-accidental call volume but is not a distributed control and does not replace
-Twilio account spend limits or deployment-level abuse protection.
+The sample also permits at most five fully validated live dial attempts per
+process each minute after exact token authorization and provider configuration
+validation. The authorized live dial quota is not consumed by unauthorized
+requests, so it bounds accidental or automated call volume but does not bound
+online token guessing. Backward wall-clock adjustments fail closed instead of
+resetting quota. This is not a distributed control and does not replace Twilio
+account spend limits or deployment-level abuse protection.
 
 The dial form rejects duplicate phone-number or authorization-token fields,
 malformed UTF-8 bytes, and malformed percent encoding before authorization or

--- a/VISION.md
+++ b/VISION.md
@@ -32,7 +32,8 @@ Priority:
 - Keep outbound calls in dry-run mode unless explicitly enabled
 - Require per-request authorization before any live dial attempt
 - Authorize live requests before disclosing provider configuration details
-- Bound live dial attempts before form parsing or authorization checks
+- Bound the authorized live dial quota after parsing and authorization, and
+  preserve it across backward wall-clock adjustments
 - Reject duplicate or malformed security-relevant dial form fields before
   authorization and provider configuration
 - Strict UTF-8 form decoding rejects malformed bytes before unknown-field filtering.

--- a/docs/plans/2026-06-26-live-dial-clock-rollback.md
+++ b/docs/plans/2026-06-26-live-dial-clock-rollback.md
@@ -1,0 +1,35 @@
+# Live Dial Clock Rollback
+
+## Status: Completed
+
+## Problem
+
+The fixed-window limiter reset attempts whenever the wall clock moved backward.
+An exhausted process could therefore accept additional authorized live calls
+before the original 60-second window elapsed. Public guidance also still
+described the obsolete pre-authorization quota ordering.
+
+## Scope
+
+- Preserve exhausted quota when the clock moves backward.
+- Reset only after time reaches the original window expiry.
+- Keep overflow-safe elapsed comparison, five-attempt allowance, `429` response,
+  request-ID ledger, authorization order, dry-run behavior, and provider boundary.
+- Correct documentation without claiming token-guessing protection.
+
+## Work Completed
+
+- Added a deterministic red-first JUnit rollback regression.
+- Added a fail-closed elapsed-window helper to the synchronized limiter.
+- Updated source, test, plan, and public documentation contracts.
+
+## Verification Completed
+
+- The focused regression failed before implementation and passed afterward.
+- Full `make check` passed with Maven 3.9.11 on Java 21.
+- Isolated source, test, and documentation hostile mutations were rejected.
+
+## Boundary
+
+This does not add distributed state, per-client identity, retries, live Twilio
+calls, token logging, or a claim that the quota prevents online token guessing.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -47,6 +47,7 @@ for path in \
   "docs/plans/2026-06-21-make-authority-hardening.md" \
   "docs/plans/2026-06-25-strict-form-utf8.md" \
   "docs/plans/2026-06-25-debug-log-redaction.md" \
+  "docs/plans/2026-06-26-live-dial-clock-rollback.md" \
   "scripts/run-make.sh" \
   "scripts/test-makefile-authority.sh" \
   "scripts/test-workflow-authority.sh" \
@@ -185,12 +186,40 @@ for rate_limit_contract in \
   'exchange.getResponseHeaders().set("Retry-After", "60")' \
   'new HttpResult(429, "Too many live dial attempts.")' \
   'liveDialRateLimiterAllowsFiveAttemptsAndResetsAfterOneMinute' \
+  'liveDialRateLimiterDoesNotResetWhenClockMovesBackward' \
+  'if (nowMillis < windowStartedAt)' \
+  'return elapsedMillis < 0L || elapsedMillis >= windowMillis;' \
   'liveDialRouteRateLimitsOnlyAfterParsingAndAuthorization' \
   'unauthorizedLiveDialRequestsDoNotConsumeTheAuthorizedRateLimit' \
   'dryRunRouteIgnoresExhaustedLiveDialRateLimit'; do
   if ! grep -Fq -- "$rate_limit_contract" "$ROOT_DIR/src/main/java/org/example/Main.java" && \
      ! grep -Fq -- "$rate_limit_contract" "$ROOT_DIR/src/test/java/org/example/MainTest.java"; then
     printf '%s\n' "Live dial rate-limit contract is missing: $rate_limit_contract" >&2
+    exit 1
+  fi
+done
+
+for rate_limit_doc in "$README" "$ROOT_DIR/SECURITY.md" "$ROOT_DIR/VISION.md" "$ROOT_DIR/CHANGES.md"; do
+  if ! grep -Fq -- "authorized live dial quota" "$rate_limit_doc"; then
+    printf '%s\n' "$rate_limit_doc must document the authorized live dial quota." >&2
+    exit 1
+  fi
+done
+
+for stale_rate_limit_claim in \
+  'before form parsing or token comparison' \
+  'This bounds token guessing' \
+  'Bound live dial attempts before form parsing or authorization checks'; do
+  if grep -Fq -- "$stale_rate_limit_claim" "$README" "$ROOT_DIR/SECURITY.md" "$ROOT_DIR/VISION.md"; then
+    printf '%s\n' "Public guidance retains a stale rate-limit claim: $stale_rate_limit_claim" >&2
+    exit 1
+  fi
+done
+
+ROLLBACK_PLAN="$ROOT_DIR/docs/plans/2026-06-26-live-dial-clock-rollback.md"
+for rollback_contract in 'Status: Completed' 'clock moves backward' 'hostile mutations'; do
+  if ! grep -Fq -- "$rollback_contract" "$ROLLBACK_PLAN"; then
+    printf '%s\n' "Live dial clock-rollback plan is missing evidence: $rollback_contract" >&2
     exit 1
   fi
 done

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -642,8 +642,7 @@ public class Main {
 
         synchronized boolean tryAcquire(long nowMillis) {
             if (windowStartedAt == Long.MIN_VALUE
-                    || nowMillis < windowStartedAt
-                    || nowMillis - windowStartedAt >= windowMillis) {
+                    || windowElapsed(nowMillis)) {
                 windowStartedAt = nowMillis;
                 attempts = 0;
             }
@@ -652,6 +651,14 @@ public class Main {
             }
             attempts++;
             return true;
+        }
+
+        private boolean windowElapsed(long nowMillis) {
+            if (nowMillis < windowStartedAt) {
+                return false;
+            }
+            long elapsedMillis = nowMillis - windowStartedAt;
+            return elapsedMillis < 0L || elapsedMillis >= windowMillis;
         }
 
         synchronized void reset() {

--- a/src/test/java/org/example/MainTest.java
+++ b/src/test/java/org/example/MainTest.java
@@ -556,6 +556,17 @@ public class MainTest {
     }
 
     @Test
+    public void liveDialRateLimiterDoesNotResetWhenClockMovesBackward() {
+        Main.LiveDialRateLimiter limiter = new Main.LiveDialRateLimiter(2, 60_000L);
+
+        assertTrue(limiter.tryAcquire(1_000L));
+        assertTrue(limiter.tryAcquire(1_000L));
+        assertFalse(limiter.tryAcquire(999L));
+        assertFalse(limiter.tryAcquire(60_999L));
+        assertTrue(limiter.tryAcquire(61_000L));
+    }
+
+    @Test
     public void liveDialRouteRateLimitsOnlyAfterParsingAndAuthorization() throws Exception {
         String originalNumber = Main.twilioNumber;
         String originalBaseUrl = Main.NGROK_BASE_URL;


### PR DESCRIPTION
## Summary
- keep exhausted authorized live-call quota fail closed when wall time moves backward
- correct stale public claims about authorization-first quota ordering and token guessing

## Baseline
- a backward wall-clock movement could prematurely reopen an exhausted live-dial quota window

## Improvements
- add a deterministic limiter regression and durable source, test, and documentation contracts

## Validation
- repository `make check` passed 55 JUnit tests
- three isolated hostile mutations, runtime dependency resolution, and `git diff --check` passed

## Risk
- no live Twilio request, credential, account, or telephone call was used; provider behavior remains outside this deterministic limiter validation

## Follow-Ups
- preserve monotonic fail-closed quota behavior and authorization-first ordering in future dial-path changes
